### PR TITLE
[Refac] 스토리북 내부 map 사용으로 인한 any 타입 제거

### DIFF
--- a/components/Icon/Icon.stories.tsx
+++ b/components/Icon/Icon.stories.tsx
@@ -4,7 +4,7 @@ import { Story } from "@storybook/react";
 
 import Icon from "./Icon";
 import { iconList } from "./assets";
-import { FontSize, Palette } from "@/foundations";
+import { Typography } from "@/components";
 
 import type IconProps from "./Icon.types";
 
@@ -24,7 +24,7 @@ export const Examples = () => (
     {iconList.map((icon) => (
       <IconChip key={icon}>
         <Icon name={icon} />
-        <IconName>{icon}</IconName>
+        <Typography size="cap1">{icon}</Typography>
       </IconChip>
     ))}
   </Layout>
@@ -43,10 +43,4 @@ const IconChip = styled.div`
 
   width: 100px;
   height: 100px;
-`;
-
-const IconName = styled.span`
-  color: ${Palette.black};
-  font-size: ${FontSize.cap1}px;
-  letter-spacing: 0.03rem;
 `;

--- a/components/Typography/Typography.stories.tsx
+++ b/components/Typography/Typography.stories.tsx
@@ -3,7 +3,9 @@ import styled from "styled-components";
 import { Story } from "@storybook/react";
 
 import Typography from "./Typography";
-import { FontSize, FontWeight } from "@/foundations";
+import { FontSize } from "@/foundations";
+import { fontSizeList } from "@/foundations/FontSize/FontSize";
+import { fontWeightList } from "@/foundations/FontWeight/FontWeight";
 
 import type TypoProps from "./Typography.types";
 
@@ -21,9 +23,8 @@ Default.args = {
 };
 
 export const Examples = () =>
-  // TODO: any 타입 제거하기
-  Object.keys(FontSize).map((size: any) =>
-    Object.keys(FontWeight).map((weight: any) => (
+  fontSizeList.map((size) =>
+    fontWeightList.map((weight) => (
       <Layout key={weight}>
         <Info>
           <Typography size={size} weight={weight}>

--- a/components/Typography/Typography.styled.ts
+++ b/components/Typography/Typography.styled.ts
@@ -4,7 +4,6 @@ import { FontSize, FontWeight, Theme } from "@/foundations";
 import type TypoProps from "./Typography.types";
 
 export const TypoStyle = css<TypoProps>`
-  font-family: "Spoqa Han Sans Neo", sans-serif;
   font-size: ${({ size }) => (size ? FontSize[size] : FontSize.body2)}px;
   font-weight: ${({ weight }) => weight && FontWeight[weight]};
   color: ${({ color }) => color && Theme.textColor[color]};

--- a/components/Typography/Typography.tsx
+++ b/components/Typography/Typography.tsx
@@ -1,16 +1,10 @@
 import React from "react";
 
 import TypoView from "./Typography.styled";
-import { FontSize, FontWeight, Theme } from "@/foundations";
 
 import type TypoProps from "./Typography.types";
 
-const Typography = ({
-  weight = FontWeight.regular,
-  size = FontSize.body2,
-  color = Theme.textColor.black,
-  children,
-}: TypoProps) => {
+const Typography = ({ weight, size, color, children }: TypoProps) => {
   return (
     <TypoView weight={weight} size={size} color={color}>
       {children}

--- a/foundations/Color/Palette/Palette.stories.tsx
+++ b/foundations/Color/Palette/Palette.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import Palette, { paletteList } from "./Palette";
-import { FontSize, FontWeight } from "@/foundations";
+import { Typography } from "@/components";
 
 export default {
   title: "Foundations/Color",
@@ -18,8 +18,12 @@ export const PaletteTemplate = () => (
     {paletteList.map((paletteKey) => (
       <ColorChip>
         <ColorTile color={Palette[paletteKey]} />
-        <ColorName>{paletteKey}</ColorName>
-        <ColorCode>{Palette[paletteKey]}</ColorCode>
+        <Typography size="body2" weight="bold" color="darkest">
+          {paletteKey}
+        </Typography>
+        <Typography size="cap1" color="lighter">
+          {Palette[paletteKey]}
+        </Typography>
       </ColorChip>
     ))}
   </Layout>
@@ -48,18 +52,4 @@ const ColorTile = styled.div<PaletteProps>`
   margin-bottom: 4px;
   border-radius: 12px;
   background-color: ${({ color }) => color};
-`;
-
-const ColorName = styled.span`
-  color: ${Palette.gray900};
-  font-size: ${FontSize.body2}px;
-  font-weight: ${FontWeight.bold};
-  letter-spacing: 0.03rem;
-`;
-
-const ColorCode = styled.span`
-  color: ${Palette.gray500};
-  font-size: ${FontSize.cap1}px;
-  font-weight: ${FontWeight.bold};
-  letter-spacing: 0.03rem;
 `;

--- a/foundations/Color/Palette/Palette.stories.tsx
+++ b/foundations/Color/Palette/Palette.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import Palette from "./";
+import Palette, { paletteList } from "./Palette";
 import { FontSize, FontWeight } from "@/foundations";
 
 export default {
@@ -15,7 +15,7 @@ interface PaletteProps {
 
 export const PaletteTemplate = () => (
   <Layout>
-    {Object.keys(Palette).map((paletteKey) => (
+    {paletteList.map((paletteKey) => (
       <ColorChip>
         <ColorTile color={Palette[paletteKey]} />
         <ColorName>{paletteKey}</ColorName>

--- a/foundations/Color/Palette/Palette.ts
+++ b/foundations/Color/Palette/Palette.ts
@@ -1,6 +1,5 @@
 import PaletteType, { PaletteKey } from "./Palette.types";
 
-// TODO : any -> 적절한 타입으로 변경
 const Palette: PaletteType = {
   // Blue
   blue50: "#E7F8FF",

--- a/foundations/Color/Palette/Palette.ts
+++ b/foundations/Color/Palette/Palette.ts
@@ -1,7 +1,7 @@
-import type PaletteType from "./Palette.types";
+import PaletteType, { PaletteKey } from "./Palette.types";
 
 // TODO : any -> 적절한 타입으로 변경
-const Palette: PaletteType | any = {
+const Palette: PaletteType = {
   // Blue
   blue50: "#E7F8FF",
   blue100: "#34B6EA",
@@ -35,5 +35,7 @@ const Palette: PaletteType | any = {
   // Black
   black: "#000000",
 };
+
+export const paletteList: PaletteKey[] = Object.keys(Palette) as PaletteKey[];
 
 export default Palette;

--- a/foundations/Color/Palette/Palette.types.ts
+++ b/foundations/Color/Palette/Palette.types.ts
@@ -33,7 +33,7 @@ type ColorfulPaletteKey =
   | `${BasePaletteKey.Coral}100`
   | `${BasePaletteKey.Coral}200`;
 
-type PaletteKey =
+export type PaletteKey =
   | ColorfulPaletteKey
   | GrayPaletteKey
   | BasePaletteKey.White

--- a/foundations/Color/Theme/Theme.stories.tsx
+++ b/foundations/Color/Theme/Theme.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import Theme, { ThemeKey } from "./Theme";
-import { FontSize, FontWeight } from "@/foundations";
+import Theme from "./Theme";
+import { Typography } from "@/components";
 
 export default {
   title: "Foundations/Color",
@@ -29,8 +29,12 @@ export const ThemeTemplate = () => (
           {Object.keys(Theme[themeType]).map((paletteKey) => (
             <ColorChip>
               <ColorTile color={Theme[themeType][paletteKey]} />
-              <ColorName>{paletteKey}</ColorName>
-              <ColorCode>{Theme[themeType][paletteKey]}</ColorCode>
+              <Typography size="body2" weight="bold" color="darkest">
+                {paletteKey}
+              </Typography>
+              <Typography size="cap1" color="lighter">
+                {Theme[themeType][paletteKey]}
+              </Typography>
             </ColorChip>
           ))}
         </Layout>
@@ -67,18 +71,4 @@ const ColorTile = styled.div<PaletteProps>`
   margin-bottom: 4px;
   border-radius: 12px;
   background-color: ${({ color }) => color};
-`;
-
-const ColorName = styled.span`
-  color: ${Theme.textColor.darkest};
-  font-size: ${FontSize.body2}px;
-  font-weight: ${FontWeight.bold};
-  letter-spacing: 0.03rem;
-`;
-
-const ColorCode = styled.span`
-  color: ${Theme.textColor.lighter};
-  font-size: ${FontSize.cap1}px;
-  font-weight: ${FontWeight.bold};
-  letter-spacing: 0.03rem;
 `;

--- a/foundations/Color/Theme/Theme.stories.tsx
+++ b/foundations/Color/Theme/Theme.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import Theme from "./Theme";
+import Theme, { ThemeKey } from "./Theme";
 import { FontSize, FontWeight } from "@/foundations";
 
 export default {
@@ -13,8 +13,7 @@ interface PaletteProps {
   color: string;
 }
 
-// TODO : any -> 적절한 타입으로 변경
-const title: any = {
+const title: { [index: string]: string } = {
   bgColor: "배경",
   selectBgColor: "선택",
   borderColor: "테두리",

--- a/foundations/Color/Theme/Theme.ts
+++ b/foundations/Color/Theme/Theme.ts
@@ -2,7 +2,7 @@ import { Palette } from "../";
 import type ThemeType from "./Theme.types";
 
 // TODO : any -> 적절한 타입으로 변경
-const Theme: ThemeType | any = {
+const Theme: ThemeType = {
   bgColor: {
     white: Palette.white,
     lighter: Palette.gray100,
@@ -36,5 +36,15 @@ const Theme: ThemeType | any = {
     warning: Palette.coral100,
   },
 };
+
+export type ThemeKey =
+  | "bgColor"
+  | "selectBgColor"
+  | "borderColor"
+  | "textColor";
+
+// export const themeList: ThemeType = Object.fromEntries(
+//   Object.entries(Theme).map(([key, value]) => [key, Object.keys(value)])
+// );
 
 export default Theme;

--- a/foundations/Color/Theme/Theme.ts
+++ b/foundations/Color/Theme/Theme.ts
@@ -1,7 +1,6 @@
 import { Palette } from "../";
 import type ThemeType from "./Theme.types";
 
-// TODO : any -> 적절한 타입으로 변경
 const Theme: ThemeType = {
   bgColor: {
     white: Palette.white,

--- a/foundations/Color/Theme/Theme.ts
+++ b/foundations/Color/Theme/Theme.ts
@@ -36,14 +36,4 @@ const Theme: ThemeType = {
   },
 };
 
-export type ThemeKey =
-  | "bgColor"
-  | "selectBgColor"
-  | "borderColor"
-  | "textColor";
-
-// export const themeList: ThemeType = Object.fromEntries(
-//   Object.entries(Theme).map(([key, value]) => [key, Object.keys(value)])
-// );
-
 export default Theme;

--- a/foundations/Color/Theme/Theme.types.ts
+++ b/foundations/Color/Theme/Theme.types.ts
@@ -28,6 +28,7 @@ export type textColor =
   | "warning";
 
 interface ThemeType {
+  [category: string]: { [color: string]: string };
   bgColor: Record<bgColor, string>;
   selectBgColor: Record<selectBgColor, string>;
   borderColor: Record<borderColor, string>;

--- a/foundations/FontSize/FontSize.stories.tsx
+++ b/foundations/FontSize/FontSize.stories.tsx
@@ -26,9 +26,6 @@ FontWeightTemplate.storyName = "Font Size";
 const Layout = styled.div<FontWeightProps>`
   display: flex;
   align-items: center;
-
-  // TODO : 폰트 패밀리는 글로벌 스타일로 적용해야해요.
-  font-family: "Spoqa Han Sans Neo", sans-serif;
   font-weight: ${FontWeight.regular};
   font-size: ${({ fontSize }) => fontSize}px;
 `;

--- a/foundations/FontSize/FontSize.stories.tsx
+++ b/foundations/FontSize/FontSize.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { FontSize, FontWeight } from "@/foundations";
+import { fontSizeList } from "@/foundations/FontSize/FontSize";
 
 export default {
   title: "Foundations/Font Size",
@@ -13,7 +14,7 @@ interface FontWeightProps {
 }
 
 export const FontWeightTemplate = () =>
-  Object.keys(FontSize).map((fontSizeKey) => (
+  fontSizeList.map((fontSizeKey) => (
     <Layout fontSize={FontSize[fontSizeKey]}>
       <Name>{fontSizeKey}</Name>
       <Number>{FontSize[fontSizeKey]}</Number>

--- a/foundations/FontSize/FontSize.stories.tsx
+++ b/foundations/FontSize/FontSize.stories.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
-import { FontSize, FontWeight } from "@/foundations";
-import { fontSizeList } from "@/foundations/FontSize/FontSize";
+import FontSize, { fontSizeList } from "./FontSize";
 
 export default {
   title: "Foundations/Font Size",
@@ -27,7 +26,6 @@ FontWeightTemplate.storyName = "Font Size";
 const Layout = styled.div<FontWeightProps>`
   display: flex;
   align-items: center;
-  font-weight: ${FontWeight.regular};
   font-size: ${({ fontSize }) => fontSize}px;
 `;
 

--- a/foundations/FontSize/FontSize.ts
+++ b/foundations/FontSize/FontSize.ts
@@ -1,7 +1,6 @@
-import type FontSizeType from "./FontSize.types";
+import FontSizeType, { FontSizeKey } from "./FontSize.types";
 
-// TODO : any -> 적절한 타입으로 변경
-const FontSize: FontSizeType | any = {
+const FontSize: FontSizeType = {
   h1: 26,
   h2: 22,
   sub1: 18,
@@ -13,5 +12,9 @@ const FontSize: FontSizeType | any = {
   cap1: 12,
   cap2: 10,
 };
+
+export const fontSizeList: FontSizeKey[] = Object.keys(
+  FontSize
+) as FontSizeKey[];
 
 export default FontSize;

--- a/foundations/FontWeight/FontWeight.stories.tsx
+++ b/foundations/FontWeight/FontWeight.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 
+import { fontWeightList } from "@/foundations/FontWeight/FontWeight";
 import { FontSize, FontWeight } from "@/foundations";
 
 export default {
@@ -13,7 +14,7 @@ interface FontWeightProps {
 }
 
 export const FontWeightTemplate = () =>
-  Object.keys(FontWeight).map((fontWeightKey) => (
+  fontWeightList.map((fontWeightKey) => (
     <Layout fontWeight={FontWeight[fontWeightKey]}>
       <Name>{fontWeightKey}</Name>
       <Number>{FontWeight[fontWeightKey]}</Number>

--- a/foundations/FontWeight/FontWeight.stories.tsx
+++ b/foundations/FontWeight/FontWeight.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import styled from "styled-components";
 
-import { fontWeightList } from "@/foundations/FontWeight/FontWeight";
-import { FontSize, FontWeight } from "@/foundations";
+import FontWeight, { fontWeightList } from "./FontWeight";
+import { FontSize } from "@/foundations";
 
 export default {
   title: "Foundations/Font Weight",

--- a/foundations/FontWeight/FontWeight.stories.tsx
+++ b/foundations/FontWeight/FontWeight.stories.tsx
@@ -26,9 +26,6 @@ FontWeightTemplate.storyName = "Font Weight";
 const Layout = styled.div<FontWeightProps>`
   display: flex;
   align-items: center;
-
-  // TODO : 폰트 패밀리는 글로벌 스타일로 적용해야해요.
-  font-family: "Spoqa Han Sans Neo", sans-serif;
   font-weight: ${({ fontWeight }) => fontWeight};
   font-size: ${FontSize.h1}px;
 `;

--- a/foundations/FontWeight/FontWeight.ts
+++ b/foundations/FontWeight/FontWeight.ts
@@ -1,11 +1,14 @@
-import type FontWeightType from "./FontWeight.types";
+import FontWeightType, { FontWeightKey } from "./FontWeight.types";
 
-// TODO : any -> 적절한 타입으로 변경
-const FontWeight: FontWeightType | any = {
+const FontWeight: FontWeightType = {
   bold: 700,
   medium: 500,
   regular: 400,
   light: 300,
 };
+
+export const fontWeightList: FontWeightKey[] = Object.keys(
+  FontWeight
+) as FontWeightKey[];
 
 export default FontWeight;


### PR DESCRIPTION
## 📌 이슈
- close #38


<br/>

## 📝 설명

- Palette, FontSize, FontWeight에 각각 key가 담긴 배열 생성했어요. (이때 타입을 해당 key가 담긴 배열로 설정했어요)
- 이를 스토리북에서 불러와 map을 사용함으로써 any 타입을 제거했어요.

<br/>

- Theme의 경우 중첩된 객체 형태여서 리스트 변환이 어울리지 않았어요.
- ThemeType에 **Index Signature**를 선언해서 문제를 해결했어요.
   -  Index Signature는 `[category: string]: { [color: string]: string }` 로 선언했어요. 
   - `Object.keys(Theme).map()`을 사용했을 때 map 내부 key가 `string`으로 설정됨에 따라 발생하는 문제가 해결되었어요.
   - [참고](https://soopdop.github.io/2020/12/01/index-signatures-in-typescript/)

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/156180624-331d5cab-7299-4068-9647-9fd46c7d5620.png)
