### PR TITLE
[Feat] Input 컨트롤 메서드 추가

### DIFF
--- a/components/Icon/Icon.styled.ts
+++ b/components/Icon/Icon.styled.ts
@@ -1,7 +1,11 @@
 import styled from "styled-components";
+import { Theme } from "@/foundations";
 
-const Svg = styled.svg`
+import type IconProps from "./Icon.types";
+
+const Svg = styled.svg<IconProps>`
   flex: 0 0 auto;
+  color: ${({ color }) => color && Theme.textColor[color]};
 `;
 
 export default Svg;

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -5,8 +5,8 @@ import icons from "./assets";
 
 import type IconProps from "./Icon.types";
 
-const Icon = ({ name }: IconProps) => {
-  return <Svg as={icons[name]} />;
+const Icon = ({ name, width = "30", height = "30" }: IconProps) => {
+  return <Svg as={icons[name]} width={width} height={height} />;
 };
 
 export default Icon;

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -10,8 +10,7 @@ const Icon = ({
   width = "30",
   height = "30",
   color = "darkest",
-}: IconProps) => {
-  return <Svg as={icons[name]} width={width} height={height} color={color} />;
-};
-
+}: IconProps) => (
+  <Svg as={icons[name]} width={width} height={height} color={color} />
+);
 export default Icon;

--- a/components/Icon/Icon.tsx
+++ b/components/Icon/Icon.tsx
@@ -5,8 +5,13 @@ import icons from "./assets";
 
 import type IconProps from "./Icon.types";
 
-const Icon = ({ name, width = "30", height = "30" }: IconProps) => {
-  return <Svg as={icons[name]} width={width} height={height} />;
+const Icon = ({
+  name,
+  width = "30",
+  height = "30",
+  color = "darkest",
+}: IconProps) => {
+  return <Svg as={icons[name]} width={width} height={height} color={color} />;
 };
 
 export default Icon;

--- a/components/Icon/Icon.types.ts
+++ b/components/Icon/Icon.types.ts
@@ -1,9 +1,11 @@
 import { IconName } from "./assets";
+import type { textColor } from "@/foundations/Color/Theme/Theme.types";
 
 interface IconOptions {
   name: IconName;
   width?: string;
   height?: string;
+  color?: textColor;
 }
 
 // 확장성 고려

--- a/components/Icon/Icon.types.ts
+++ b/components/Icon/Icon.types.ts
@@ -2,6 +2,8 @@ import { IconName } from "./assets";
 
 interface IconOptions {
   name: IconName;
+  width?: string;
+  height?: string;
 }
 
 // 확장성 고려

--- a/components/Icon/assets/ChevronLeft.tsx
+++ b/components/Icon/assets/ChevronLeft.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const ChevronLeft = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/ChevronRight.tsx
+++ b/components/Icon/assets/ChevronRight.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const ChevronRight = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/Edit.tsx
+++ b/components/Icon/assets/Edit.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const Edit = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/List.tsx
+++ b/components/Icon/assets/List.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const List = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/MapPin.tsx
+++ b/components/Icon/assets/MapPin.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const MapPin = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/Menu.tsx
+++ b/components/Icon/assets/Menu.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const Menu = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/MoreHorizontal.tsx
+++ b/components/Icon/assets/MoreHorizontal.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const MoreHorizontal = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/MoreVertical.tsx
+++ b/components/Icon/assets/MoreVertical.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const MoreVertical = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/Search.tsx
+++ b/components/Icon/assets/Search.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-const Search = (props: React.SVGProps<SVGSVGElement>) => {
+// TODO : any 타입 제거
+const Search = (props: React.SVGProps<SVGSVGElement> | any) => {
   return (
     <svg
       viewBox="0 0 30 30"

--- a/components/Icon/assets/Search.tsx
+++ b/components/Icon/assets/Search.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const Search = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/Share.tsx
+++ b/components/Icon/assets/Share.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const Share = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/Share2.tsx
+++ b/components/Icon/assets/Share2.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const Share2 = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/Stack.tsx
+++ b/components/Icon/assets/Stack.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const Stack = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/assets/X.tsx
+++ b/components/Icon/assets/X.tsx
@@ -3,8 +3,6 @@ import React from "react";
 const X = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      width="30"
-      height="30"
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/Icon/index.ts
+++ b/components/Icon/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Icon";

--- a/components/Input/Input.stories.tsx
+++ b/components/Input/Input.stories.tsx
@@ -14,6 +14,15 @@ export const Default = ({ ...args }) => <Input {...args} />;
 export const Examples = () => (
   <Layout>
     <Typography size="sub1" weight="bold">
+      Input Controls
+    </Typography>
+    <Input />
+    <Input control="manage" />
+    <Input control="search" />
+
+    <br />
+
+    <Typography size="sub1" weight="bold">
       타이틀이 없는 경우
     </Typography>
     <Input />

--- a/components/Input/Input.styled.ts
+++ b/components/Input/Input.styled.ts
@@ -20,7 +20,7 @@ export const Layout = styled.div<LayoutProps>`
   align-items: center;
 
   height: 46px;
-  padding: 0 16px;
+  padding: 0 14px 0 16px;
   border-radius: 4px;
   box-sizing: border-box;
 

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -24,7 +24,7 @@ const Input = ({
   const ControlRender = (control: ControlType) => {
     switch (control) {
       case "clear":
-        return !disabled ? <Clear /> : null;
+        return !disabled && <Clear />;
       case "manage":
         return <Manage />;
       case "search":

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -7,7 +7,9 @@ import {
   ErrorMsg,
   Description,
 } from "./Input.styled";
-import type { InputProps } from "./Input.types";
+import { Clear, Manage, Search } from "./controls";
+
+import type { InputProps, ControlType } from "./Input.types";
 
 const Input = ({
   label,
@@ -17,7 +19,19 @@ const Input = ({
   disabled,
   errorMsg,
   description,
+  control = "clear",
 }: InputProps) => {
+  const ControlRender = (control: ControlType) => {
+    switch (control) {
+      case "clear":
+        return !disabled ? <Clear /> : null;
+      case "manage":
+        return <Manage />;
+      case "search":
+        return <Search />;
+    }
+  };
+
   return (
     <div>
       {label && (
@@ -37,6 +51,7 @@ const Input = ({
           disabled={disabled}
           required={required}
         />
+        {control && ControlRender(control)}
       </Layout>
       {hasError && (
         <ErrorMsg color="warning" size="cap1" weight="bold">

--- a/components/Input/Input.types.ts
+++ b/components/Input/Input.types.ts
@@ -7,11 +7,18 @@ type InputType =
   | "password"
   | "number";
 
+export type ControlType =
+  | "clear"
+  | "manage"
+  | "search";
+
 interface InputOptions {
   type?: InputType;
   label?: string;
   errorMsg?: string;
   description?: string;
+  control?: ControlType;
 }
 
+// prettier-ignore
 export interface InputProps extends FormProps, InputOptions {}

--- a/components/Input/controls/Clear/Clear.stories.tsx
+++ b/components/Input/controls/Clear/Clear.stories.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Clear from "./Clear";
+
+export default {
+  title: "Components/Input/Controls",
+  component: Clear,
+};
+
+export const ClearItem = () => <Clear />;
+
+ClearItem.storyName = "Clear";

--- a/components/Input/controls/Clear/Clear.styled.ts
+++ b/components/Input/controls/Clear/Clear.styled.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const Svg = styled.svg`
+  cursor: pointer;
+`;

--- a/components/Input/controls/Clear/Clear.tsx
+++ b/components/Input/controls/Clear/Clear.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { Svg } from "./Clear.styled";
+import { Theme } from "@/foundations";
+
+const Clear = () => (
+  <Svg
+    width="30"
+    height="30"
+    viewBox="0 0 30 30"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="15" cy="15" r="10" fill={Theme.bgColor.light} />
+    <path
+      d="M12 12L18 18"
+      stroke={Theme.textColor.light}
+      stroke-width="1.2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M12 18L18 12"
+      stroke={Theme.textColor.light}
+      stroke-width="1.2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </Svg>
+);
+
+export default Clear;

--- a/components/Input/controls/Clear/index.ts
+++ b/components/Input/controls/Clear/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Clear";

--- a/components/Input/controls/Manage/Manage.stories.tsx
+++ b/components/Input/controls/Manage/Manage.stories.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Manage from "./Manage";
+
+export default {
+  title: "Components/Input/Controls",
+  component: Manage,
+};
+
+export const ManageItem = () => <Manage />;
+
+ManageItem.storyName = "Manage";

--- a/components/Input/controls/Manage/Manage.styled.ts
+++ b/components/Input/controls/Manage/Manage.styled.ts
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+export const Layout = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 0 0 auto;
+
+  width: 30px;
+  height: 30px;
+
+  cursor: pointer;
+  user-select: none;
+`;

--- a/components/Input/controls/Manage/Manage.tsx
+++ b/components/Input/controls/Manage/Manage.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Layout } from "./Manage.styled";
+import { Typography } from "@/components";
+
+const Manage = () => (
+  <Layout>
+    <Typography size="body2" weight="bold" color="primary">
+      관리
+    </Typography>
+  </Layout>
+);
+
+export default Manage;

--- a/components/Input/controls/Manage/index.ts
+++ b/components/Input/controls/Manage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Manage";

--- a/components/Input/controls/Search/Search.stories.tsx
+++ b/components/Input/controls/Search/Search.stories.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Search from "./Search";
+
+export default {
+  title: "Components/Input/Controls",
+  component: Search,
+};
+
+export const SearchItem = () => <Search />;
+
+SearchItem.storyName = "Search";

--- a/components/Input/controls/Search/Search.styled.ts
+++ b/components/Input/controls/Search/Search.styled.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const IconBox = styled.div`
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+`;

--- a/components/Input/controls/Search/Search.tsx
+++ b/components/Input/controls/Search/Search.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { IconBox } from "./Search.styled";
+import { Icon } from "@/components";
+
+const Search = () => (
+  <IconBox>
+    <Icon name="search" color="darkest" />
+  </IconBox>
+);
+
+export default Search;

--- a/components/Input/controls/Search/index.ts
+++ b/components/Input/controls/Search/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Search";

--- a/components/Input/controls/index.ts
+++ b/components/Input/controls/index.ts
@@ -1,0 +1,3 @@
+export { default as Clear } from "./Clear";
+export { default as Manage } from "./Manage";
+export { default as Search } from "./Search";

--- a/components/Input/index.ts
+++ b/components/Input/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Input";

--- a/components/Typography/Typography.tsx
+++ b/components/Typography/Typography.tsx
@@ -4,12 +4,10 @@ import TypoView from "./Typography.styled";
 
 import type TypoProps from "./Typography.types";
 
-const Typography = ({ weight, size, color, children }: TypoProps) => {
-  return (
-    <TypoView weight={weight} size={size} color={color}>
-      {children}
-    </TypoView>
-  );
-};
+const Typography = ({ weight, size, color, children }: TypoProps) => (
+  <TypoView weight={weight} size={size} color={color}>
+    {children}
+  </TypoView>
+);
 
 export default Typography;

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,1 +1,3 @@
+export { default as Icon } from "./Icon";
+export { default as Input } from "./Input";
 export { default as Typography } from "./Typography";

--- a/foundations/Color/Palette/Palette.stories.tsx
+++ b/foundations/Color/Palette/Palette.stories.tsx
@@ -41,14 +41,14 @@ const ColorChip = styled.div`
   flex-direction: column;
   align-items: center;
 
-  width: 150px;
-  height: 150px;
+  width: 100px;
+  height: 120px;
   margin: 10px;
 `;
 
 const ColorTile = styled.div<PaletteProps>`
-  width: 100px;
-  height: 100px;
+  width: 80px;
+  height: 80px;
   margin-bottom: 4px;
   border-radius: 12px;
   background-color: ${({ color }) => color};

--- a/foundations/Color/Theme/Theme.stories.tsx
+++ b/foundations/Color/Theme/Theme.stories.tsx
@@ -48,11 +48,12 @@ ThemeTemplate.storyName = "Theme";
 const Layout = styled.div`
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: 80px;
+  margin-bottom: 40px;
 `;
 
 const TypeTitle = styled.h3`
-  padding-left: 35px;
+  padding-left: 20px;
+  margin-bottom: 0;
 `;
 
 const ColorChip = styled.div`
@@ -60,14 +61,14 @@ const ColorChip = styled.div`
   flex-direction: column;
   align-items: center;
 
-  width: 150px;
-  height: 150px;
+  width: 100px;
+  height: 120px;
   margin: 10px;
 `;
 
 const ColorTile = styled.div<PaletteProps>`
-  width: 100px;
-  height: 100px;
+  width: 80px;
+  height: 80px;
   margin-bottom: 4px;
   border-radius: 12px;
   background-color: ${({ color }) => color};


### PR DESCRIPTION
## 📌 이슈
- close #34


<br/>

## 📝 설명

- Icon을 다른 컴포넌트에서 사용하기 위해 `width`, `height`, `color` props를 추가했어요.

<br/>

- clear, manage, search 메서드를 Input에 추가했어요.
   - clear 메서드는 `<Icon name="x" />`를 사용하려 했지만 해당 svg가 path로 이루어져 있어서, 높이와 너비를 줄이면 선 굵기까지 함께 가늘어지는 현상이 있었어요.
   - 그래서 아쉽지만 Clear 컴포넌트는 별도의 svg로 작성했어요.

<br/>


- 메서드 기능은 react-hook-form 도입 시 구현할 예정이에요.
   - value, onChange, clear 등을 react-hook-form을 통해 컨트롤 할 수 있어요.

<br/>

- 그 외 소소한 리팩토링, 디테일 수정 등을 진행헀어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/156210288-1b4e734e-28f5-4d51-bd43-f8ebeb280b64.png)
