### PR TITLE
[Feat] Badge 컴포넌트 생성

### DIFF
--- a/components/Badge/Badge.stories.tsx
+++ b/components/Badge/Badge.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { Story } from "@storybook/react";
+
+import Badge from "./Badge";
+import type { BadgeProps } from "./Badge.types";
+
+export default {
+  title: "Components/Badge",
+  component: Badge,
+};
+
+export const Default: Story<BadgeProps> = ({ ...args }) => <Badge {...args} />;
+
+export const Examples = () => (
+  <>
+    <Badge isOngoing={true} /> <Badge isOngoing={false} />
+  </>
+);

--- a/components/Badge/Badge.styled.ts
+++ b/components/Badge/Badge.styled.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+import { TypoStyle } from "@/components/Typography";
+import { Palette, Theme } from "@/foundations";
+
+import type { TypoProps } from "@/components/Typography";
+import type { BadgeProps } from "./Badge.types";
+
+export const Layout = styled.div<BadgeProps & TypoProps>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 40px;
+  height: 20px;
+  border-radius: 20px;
+  background-color: ${({ isOngoing }) =>
+    isOngoing ? Theme.badgeColor.ongoing : Theme.badgeColor.closed};
+
+  ${TypoStyle}
+  color: ${Palette.white};
+  user-select: none;
+`;

--- a/components/Badge/Badge.styled.ts
+++ b/components/Badge/Badge.styled.ts
@@ -15,7 +15,7 @@ export const Layout = styled.div<BadgeProps & TypoProps>`
   height: 20px;
   border-radius: 20px;
   background-color: ${({ isOngoing }) =>
-    isOngoing ? Theme.badgeColor.ongoing : Theme.badgeColor.closed};
+    Theme.badgeColor[isOngoing ? "ongoing" : "closed"]};
 
   ${TypoStyle}
   color: ${Palette.white};

--- a/components/Badge/Badge.tsx
+++ b/components/Badge/Badge.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { Layout } from "./Badge.styled";
+import type { BadgeProps } from "./Badge.types";
+
+const Badge = ({ isOngoing = true }: BadgeProps) => {
+  const text = isOngoing ? "진행중" : "종료";
+  return (
+    <Layout isOngoing={isOngoing} size="cap2" weight="medium">
+      {text}
+    </Layout>
+  );
+};
+
+export default Badge;

--- a/components/Badge/Badge.types.ts
+++ b/components/Badge/Badge.types.ts
@@ -1,0 +1,5 @@
+interface BadgeOptions {
+  isOngoing: boolean;
+}
+
+export interface BadgeProps extends BadgeOptions {}

--- a/foundations/Color/Theme/Theme.stories.tsx
+++ b/foundations/Color/Theme/Theme.stories.tsx
@@ -16,6 +16,7 @@ interface PaletteProps {
 const title: { [index: string]: string } = {
   bgColor: "배경",
   selectBgColor: "선택",
+  badgeColor: "뱃지",
   borderColor: "테두리",
   textColor: "텍스트",
 };
@@ -24,7 +25,12 @@ export const ThemeTemplate = () => (
   <>
     {Object.keys(Theme).map((themeType) => (
       <>
-        <TypeTitle>{title[themeType]}</TypeTitle>
+        <TitleBox>
+          <Typography size="h2" weight="bold" color="darkest">
+            {title[themeType]}
+          </Typography>{" "}
+          <Typography color="light">{themeType}</Typography>
+        </TitleBox>
         <Layout>
           {Object.keys(Theme[themeType]).map((paletteKey) => (
             <ColorChip>
@@ -51,9 +57,8 @@ const Layout = styled.div`
   margin-bottom: 40px;
 `;
 
-const TypeTitle = styled.h3`
+const TitleBox = styled.div`
   padding-left: 20px;
-  margin-bottom: 0;
 `;
 
 const ColorChip = styled.div`

--- a/foundations/Color/Theme/Theme.ts
+++ b/foundations/Color/Theme/Theme.ts
@@ -7,13 +7,17 @@ const Theme: ThemeType = {
     lighter: Palette.gray100,
     light: Palette.gray200,
     primary: Palette.blue100,
-    badge: Palette.coral200,
   },
 
   selectBgColor: {
     lighter: Palette.green50,
     light: Palette.green100,
     dark: Palette.green200,
+  },
+
+  badgeColor: {
+    ongoing: Palette.coral200,
+    closed: Palette.gray400,
   },
 
   borderColor: {

--- a/foundations/Color/Theme/Theme.types.ts
+++ b/foundations/Color/Theme/Theme.types.ts
@@ -1,15 +1,19 @@
+// prettier-ignore
 export type bgColor =
   | "white"
   | "lighter"
   | "light"
   | "primary"
-  | "badge";
 
+// prettier-ignore
 export type selectBgColor =
   | "lighter"
   | "light"
   | "dark";
 
+export type badgeColor = "ongoing" | "closed";
+
+// prettier-ignore
 export type borderColor =
   | "lighter"
   | "light"
@@ -31,6 +35,7 @@ interface ThemeType {
   [category: string]: { [color: string]: string };
   bgColor: Record<bgColor, string>;
   selectBgColor: Record<selectBgColor, string>;
+  badgeColor: Record<badgeColor, string>;
   borderColor: Record<borderColor, string>;
   textColor: Record<textColor, string>;
 }

--- a/foundations/Color/Theme/Theme.types.ts
+++ b/foundations/Color/Theme/Theme.types.ts
@@ -11,7 +11,10 @@ export type selectBgColor =
   | "light"
   | "dark";
 
-export type badgeColor = "ongoing" | "closed";
+// prettier-ignore
+export type badgeColor = 
+  | "ongoing"
+  | "closed";
 
 // prettier-ignore
 export type borderColor =


### PR DESCRIPTION
## 📌 이슈
- close #43


<br/>

## 📝 설명

- Badge 컴포넌트를 만들었어요.
- 시멘틱한 변수명을 위해 `Theme.badgeColor`를 추가했어요.
- 뱃지는 '진행중'과 '종료' 두가지 타입밖에 없어서, `isOngoing` props 하나만 설정했어요.
- `isOngoing`에 따라 배경색과 내부 텍스트가 바뀌어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/156578201-172de71f-2ec2-4f66-addd-4e87cb887ef6.png)
![image](https://user-images.githubusercontent.com/87457066/156577956-38ee93a4-2204-4e66-a9e2-b0fd437833b7.png)


