### PR TITLE
[Feat] Typography `font-size`에 따라 다른 `letter-spacing` 적용

### DIFF
--- a/components/Typography/Typography.styled.ts
+++ b/components/Typography/Typography.styled.ts
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import { FontSize, FontWeight, Theme } from "@/foundations";
 
+import { TitleList } from "@/foundations/FontSize";
 import type TypoProps from "./Typography.types";
 
 export const TypoStyle = css<TypoProps>`
@@ -8,7 +9,8 @@ export const TypoStyle = css<TypoProps>`
   font-weight: ${({ weight }) => weight && FontWeight[weight]};
   color: ${({ color }) => color && Theme.textColor[color]};
   line-height: 130%;
-  letter-spacing: -0.03rem;
+  letter-spacing: ${({ size }: any) =>
+    TitleList.includes(size) ? "-0.03rem" : "-0.02rem"};
 `;
 
 const Typography = styled.span<TypoProps>`

--- a/foundations/FontSize/FontSize.types.ts
+++ b/foundations/FontSize/FontSize.types.ts
@@ -1,14 +1,27 @@
+export const TitleList = [
+  "h1",
+  "h2",
+  "sub1",
+  "sub2",
+  "sub3",
+] as const;
+
+export const TextList = [
+  "body1",
+  "body2",
+  "body3",
+  "cap1",
+  "cap2",
+] as const;
+
+export type TitleKey = typeof TitleList[number];
+
+export type TextKey = typeof TextList[number];
+
+// prettier-ignore
 export type FontSizeKey =
-  | "h1"
-  | "h2"
-  | "sub1"
-  | "sub2"
-  | "sub3"
-  | "body1"
-  | "body2"
-  | "body3"
-  | "cap1"
-  | "cap2";
+  | TitleKey
+  | TextKey;
 
 type FontSizeType = Record<FontSizeKey, number>;
 

--- a/foundations/FontSize/index.ts
+++ b/foundations/FontSize/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./FontSize";
 export { fontSizeList } from "./FontSize";
-export type { FontSizeKey } from "./FontSize.types";
+export { TitleList, TextList } from "./FontSize.types";
+export type { TitleKey, TextKey, FontSizeKey } from "./FontSize.types";


### PR DESCRIPTION
## 📌 이슈
- close #35


<br/>

## 📝 설명

- Typography 에서 타이틀인 경우 -0.03rem, 일반 텍스트인 경우 -0.02rem을 적용했어요.

<br />

- 이를 위해서는 **size를 체크할 리스트**가 필요했어요.
   - FontSizeKey는 `string literal`이 포함된 커스텀 타입이기 때문에 `typeof size === 'TitleKey'`와 같은 체크가 불가능했거든요.
   - **[String Literal 이란?](https://soopdop.github.io/2020/12/01/index-signatures-in-typescript/#typescript%EC%97%90%EC%84%9C%EB%8A%94-%EC%95%88%EB%90%98%EB%8A%94-%EA%B2%83%EC%9D%B4-%EC%9E%88%EB%8B%A4)**


<br />

- 그래서 최대한 반복을 줄이기 위해, **FontSize.types에서 타입 선언 방식을 변경**했어요.
   - 리스트를 `const`로 먼저 선언하고, 여기서 `string literal`를 뽑아내는 방식으로요.
   - (원래는 `|`와  `string literal`을 이용해 먼저 선언하는 방식이었어요!)
   - **[참고 링크](https://stackoverflow.com/questions/51528780/typescript-check-typeof-against-custom-type)**
  ```typescript
  export const TitleList = [
    "h1",
    "h2",
    "sub1",
    "sub2",
    "sub3",
  ] as const;
  
  export type TitleKey = typeof TitleList[number];
  ```


<br />

- 그리고 FontSize.types에서 선언한 TitleList를 가져와, Typography.styled에서 `includes()`를 이용해 체크했어요.
   - 이 때 props인 `size`는 `FontSizeKey`지만, TitleList 내부에서 인덱싱할 때는 `TitleKey`여야 해요.
   - 그래서 any를 사용해줬어요.
   - 참고로 위 `font-size`와 달리 `size &&` 구문이 없는 이유는, 컴포넌트에서 `<Typography size="body2" />` 처럼 size를 적용하지 않고 `<Typography />`만 사용했을 경우에도 `letter-spacing`을 적용하기 위함이에요.
  ```css
  letter-spacing: ${({ size }: any) => TitleList.includes(size) ? "-0.03rem" : "-0.02rem"};
  ```

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/156589632-4e12e7dd-4a0a-4fdd-bedc-fd3980204617.png)
