### PR TITLE
[Feat] HelperText 컴포넌트 생성

### DIFF
--- a/components/Badge/Badge.styled.ts
+++ b/components/Badge/Badge.styled.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 import { TypoStyle } from "@/components/Typography";
-import { Palette, Theme } from "@/foundations";
+import { Theme } from "@/foundations";
 
 import type { TypoProps } from "@/components/Typography";
 import type { BadgeProps } from "./Badge.types";
@@ -18,6 +18,6 @@ export const Layout = styled.div<BadgeProps & TypoProps>`
     Theme.badgeColor[isOngoing ? "ongoing" : "closed"]};
 
   ${TypoStyle}
-  color: ${Palette.white};
+  color: ${Theme.textColor.white};
   user-select: none;
 `;

--- a/components/HelperText/HelperText.stories.tsx
+++ b/components/HelperText/HelperText.stories.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import styled from "styled-components";
+import { Story } from "@storybook/react";
+
+import HelperText from "./HelperText";
+
+import type HelperProps from "./HelperText.types";
+
+export default {
+  title: "Components/HelperText",
+  component: HelperText,
+};
+
+export const Default: Story<HelperProps> = ({ ...args }) => (
+  <HelperText {...args} />
+);
+
+Default.args = {
+  children: "텍스트",
+  color: "light",
+};
+
+export const Examples = () => (
+  <Layout>
+    <HelperText children="하람" color="light" />
+    <HelperText children="중간장소" color="dark" />
+  </Layout>
+);
+
+const Layout = styled.div`
+  display: flex;
+  gap: 10px;
+`;

--- a/components/HelperText/HelperText.styled.ts
+++ b/components/HelperText/HelperText.styled.ts
@@ -1,0 +1,45 @@
+import styled from "styled-components";
+
+import { Theme } from "@/foundations";
+import { TypoStyle } from "@/components/Typography";
+
+import type { TypoProps } from "@/components/Typography";
+import type HelperProps from "./HelperText.types";
+
+export const Layout = styled.div<HelperProps & TypoProps>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 4px;
+  border: 1px solid ${({ color }) => Theme.helperBorderColor[color]};
+
+  background-color: ${({ color }) => Theme.helperBgColor[color]};
+
+  ${TypoStyle}
+  color: ${Theme.textColor.white};
+  white-space: nowrap;
+`;
+
+export const ArrowBox = styled.div`
+  position: absolute;
+  top: 100%;
+  height: 7px;
+  overflow: hidden;
+`;
+
+export const Arrow = styled.div<HelperProps>`
+  position: relative;
+  bottom: 5.5px;
+
+  width: 9px;
+  height: 9px;
+  border: 1px solid ${({ color }) => Theme.helperBorderColor[color]};
+  border-radius: 3px;
+
+  background-color: ${({ color }) => Theme.helperBgColor[color]};
+  transform: rotate(45deg) skew(15deg, 15deg);
+`;

--- a/components/HelperText/HelperText.styled.ts
+++ b/components/HelperText/HelperText.styled.ts
@@ -1,9 +1,8 @@
 import styled from "styled-components";
 
 import { Theme } from "@/foundations";
-import { TypoStyle } from "@/components/Typography";
+import { TypoStyle, TypoProps } from "@/components/Typography";
 
-import type { TypoProps } from "@/components/Typography";
 import type HelperProps from "./HelperText.types";
 
 export const Layout = styled.div<HelperProps & TypoProps>`

--- a/components/HelperText/HelperText.styled.ts
+++ b/components/HelperText/HelperText.styled.ts
@@ -16,7 +16,6 @@ export const Layout = styled.div<HelperProps & TypoProps>`
   padding: 0 10px;
   border-radius: 4px;
   border: 1px solid ${({ color }) => Theme.helperBorderColor[color]};
-
   background-color: ${({ color }) => Theme.helperBgColor[color]};
 
   ${TypoStyle}
@@ -33,7 +32,7 @@ export const ArrowBox = styled.div`
 
 export const Arrow = styled.div<HelperProps>`
   position: relative;
-  bottom: 5.5px;
+  bottom: 6px;
 
   width: 9px;
   height: 9px;

--- a/components/HelperText/HelperText.tsx
+++ b/components/HelperText/HelperText.tsx
@@ -4,14 +4,12 @@ import { Layout, Arrow, ArrowBox } from "./HelperText.styled";
 import type HelperProps from "./HelperText.types";
 
 const HelperText = ({ children, color = "light" }: HelperProps) => (
-  <>
-    <Layout color={color} size="body3" weight="bold">
-      {children}
-      <ArrowBox>
-        <Arrow color={color} />
-      </ArrowBox>
-    </Layout>
-  </>
+  <Layout color={color} size="body3" weight="bold">
+    {children}
+    <ArrowBox>
+      <Arrow color={color} />
+    </ArrowBox>
+  </Layout>
 );
 
 export default HelperText;

--- a/components/HelperText/HelperText.tsx
+++ b/components/HelperText/HelperText.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { Layout, Arrow, ArrowBox } from "./HelperText.styled";
+import type HelperProps from "./HelperText.types";
+
+const HelperText = ({ children, color = "light" }: HelperProps) => (
+  <>
+    <Layout color={color} size="body3" weight="bold">
+      {children}
+      <ArrowBox>
+        <Arrow color={color} />
+      </ArrowBox>
+    </Layout>
+  </>
+);
+
+export default HelperText;

--- a/components/HelperText/HelperText.types.ts
+++ b/components/HelperText/HelperText.types.ts
@@ -1,0 +1,7 @@
+import { ChildrenProps } from "@/types/ComponentProps";
+
+interface HelperOptions {
+  color: "dark" | "light";
+}
+
+export default interface HelperProps extends ChildrenProps, HelperOptions {}

--- a/components/StationInfo/LineSymbol/LineSymbol.styled.ts
+++ b/components/StationInfo/LineSymbol/LineSymbol.styled.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 import { LineColor } from "../LineColor";
-import { FontWeight, Palette } from "@/foundations";
+import { FontWeight, Theme } from "@/foundations";
 
 import type { LineName } from "@/components/StationInfo";
 
@@ -26,5 +26,5 @@ export const LineNumber = styled.span<LayoutProps>`
   font-size: ${(props) => (/^\d/.test(props.text) ? 12.5 : 10)}px;
   font-weight: ${FontWeight.bold};
   line-height: 130%;
-  color: ${Palette.white};
+  color: ${Theme.textColor.white};
 `;

--- a/foundations/Color/Palette/Palette.ts
+++ b/foundations/Color/Palette/Palette.ts
@@ -4,9 +4,10 @@ const Palette: PaletteType = {
   // Blue
   blue50: "#E7F8FF",
   blue100: "#34B6EA",
-  blue200: "#1DB1EC",
+  blue200: "#00A4E5",
   blue300: "#1786FF",
-  blue400: "#35506F",
+  blue400: "#104270",
+  blue500: "#00305B",
 
   // Green
   green50: "#DBFAB5",

--- a/foundations/Color/Palette/Palette.types.ts
+++ b/foundations/Color/Palette/Palette.types.ts
@@ -27,6 +27,7 @@ type ColorfulPaletteKey =
   | `${BasePaletteKey.Blue}200`
   | `${BasePaletteKey.Blue}300`
   | `${BasePaletteKey.Blue}400`
+  | `${BasePaletteKey.Blue}500`
   | `${BasePaletteKey.Green}50`
   | `${BasePaletteKey.Green}100`
   | `${BasePaletteKey.Green}200`

--- a/foundations/Color/Theme/Theme.stories.tsx
+++ b/foundations/Color/Theme/Theme.stories.tsx
@@ -15,10 +15,12 @@ interface PaletteProps {
 
 const title: { [index: string]: string } = {
   bgColor: "배경",
-  selectBgColor: "선택",
+  selectColor: "선택",
   badgeColor: "뱃지",
   borderColor: "테두리",
   textColor: "텍스트",
+  helperBgColor: "도움말 배경",
+  helperBorderColor: "도움말 테두리",
 };
 
 export const ThemeTemplate = () =>

--- a/foundations/Color/Theme/Theme.ts
+++ b/foundations/Color/Theme/Theme.ts
@@ -9,15 +9,10 @@ const Theme: ThemeType = {
     primary: Palette.blue100,
   },
 
-  selectBgColor: {
+  selectColor: {
     lighter: Palette.green50,
     light: Palette.green100,
     dark: Palette.green200,
-  },
-
-  badgeColor: {
-    ongoing: Palette.coral200,
-    closed: Palette.gray400,
   },
 
   borderColor: {
@@ -28,6 +23,7 @@ const Theme: ThemeType = {
   },
 
   textColor: {
+    white: Palette.white,
     lightest: Palette.gray400,
     lighter: Palette.gray500,
     light: Palette.gray600,
@@ -37,6 +33,21 @@ const Theme: ThemeType = {
     black: Palette.black,
     primary: Palette.blue100,
     warning: Palette.coral100,
+  },
+
+  badgeColor: {
+    ongoing: Palette.coral200,
+    closed: Palette.gray400,
+  },
+
+  helperBgColor: {
+    light: Palette.blue100,
+    dark: Palette.blue400,
+  },
+
+  helperBorderColor: {
+    light: Palette.blue200,
+    dark: Palette.blue500,
   },
 };
 

--- a/foundations/Color/Theme/Theme.types.ts
+++ b/foundations/Color/Theme/Theme.types.ts
@@ -6,15 +6,10 @@ export type bgColor =
   | "primary"
 
 // prettier-ignore
-export type selectBgColor =
+export type selectColor =
   | "lighter"
   | "light"
   | "dark";
-
-// prettier-ignore
-export type badgeColor = 
-  | "ongoing"
-  | "closed";
 
 // prettier-ignore
 export type borderColor =
@@ -24,6 +19,7 @@ export type borderColor =
   | "warning";
 
 export type textColor =
+  | "white"
   | "lightest"
   | "lighter"
   | "light"
@@ -34,13 +30,30 @@ export type textColor =
   | "primary"
   | "warning";
 
+// prettier-ignore
+export type badgeColor = 
+  | "ongoing"
+  | "closed";
+
+// prettier-ignore
+export type helperBgColor = 
+  | "light"
+  | "dark";
+
+// prettier-ignore
+export type helperBorderColor = 
+  | "light"
+  | "dark";
+
 interface ThemeType {
   [category: string]: { [color: string]: string };
   bgColor: Record<bgColor, string>;
-  selectBgColor: Record<selectBgColor, string>;
+  selectColor: Record<selectColor, string>;
   badgeColor: Record<badgeColor, string>;
   borderColor: Record<borderColor, string>;
   textColor: Record<textColor, string>;
+  helperBgColor: Record<helperBgColor, string>;
+  helperBorderColor: Record<helperBorderColor, string>;
 }
 
 export default ThemeType;

--- a/foundations/Color/Theme/index.ts
+++ b/foundations/Color/Theme/index.ts
@@ -1,7 +1,7 @@
 export { default } from "./Theme";
 export type {
   bgColor,
-  selectBgColor,
+  selectColor,
   borderColor,
   textColor,
 } from "./Theme.types";


### PR DESCRIPTION
## 📌 이슈
- close #47


<br/>

## 📝 설명

### HelperText 컴포넌트를 만들었어요.
- 추가로 필요한 색상이 있어 Palette와 Theme에 반영했어요.
- 말풍선의 꼭지는 `rotate`와 `overflow: hidden`으로 만들었어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/156816454-d34765b8-d2c1-4995-b9fe-dc2a7204033d.png)
