### PR TITLE
[Feat] 스토리북 기본 Viewport 설정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,21 +1,24 @@
 # .github/workflows/chromatic.yml
 
 # Workflow name
-name: 'Chromatic Deployment'
+name: "Chromatic"
 
 # Event for the workflow
 on: push
 
 # List of jobs
 jobs:
-  test:
+  chromatic:
     # Operating System
     runs-on: ubuntu-latest
     # Job steps
     steps:
       - uses: actions/checkout@v1
-      - run: yarn
-      - uses: chromaui/action@v1
+      - name: Install dependencies
+        run: yarn
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        # Chromatic GitHub Action options
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import { addDecorator } from "@storybook/react";
+import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport";
 import GlobalStyle from "../styles/global";
 
 addDecorator((story) => (
@@ -20,5 +21,9 @@ export const parameters = {
     storySort: {
       order: ["Foundations", "Components", "*"],
     },
+  },
+  viewport: {
+    viewports: INITIAL_VIEWPORTS,
+    defaultViewport: "iphone12mini",
   },
 };

--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -3,6 +3,8 @@ import { create } from "@storybook/theming";
 export default create({
   base: "light",
   brandTitle: "Moida Design System",
-  brandUrl: "https://moida-ui.vercel.app/",
   brandImage: "/images/logo-storybook.svg",
+
+  colorPrimary: "#34B6EA",
+  colorSecondary: "#34B6EA",
 });

--- a/components/Badge/Badge.stories.tsx
+++ b/components/Badge/Badge.stories.tsx
@@ -7,6 +7,9 @@ import type { BadgeProps } from "./Badge.types";
 export default {
   title: "Components/Badge",
   component: Badge,
+  parameters: {
+    layout: "centered",
+  },
 };
 
 export const Default: Story<BadgeProps> = ({ ...args }) => <Badge {...args} />;
@@ -17,6 +20,7 @@ Default.args = {
 
 export const Examples = () => (
   <>
-    <Badge isOngoing={true} /> <Badge isOngoing={false} />
+    <Badge isOngoing={true} />
+    <Badge isOngoing={false} />
   </>
 );

--- a/components/GpsButton/GpsButton.stories.tsx
+++ b/components/GpsButton/GpsButton.stories.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+
 import GpsButton from "./GpsButton";
 
 export default {
   title: "Components/GpsButton",
   component: GpsButton,
+  parameters: {
+    layout: "centered",
+  },
 };
 
-export const Default = () => <GpsButton />;
+export const Default = ({ ...args }) => <GpsButton {...args} />;

--- a/components/HelperText/HelperText.stories.tsx
+++ b/components/HelperText/HelperText.stories.tsx
@@ -9,6 +9,9 @@ import type HelperProps from "./HelperText.types";
 export default {
   title: "Components/HelperText",
   component: HelperText,
+  parameters: {
+    layout: "centered",
+  },
 };
 
 export const Default: Story<HelperProps> = ({ ...args }) => (

--- a/components/Icon/Icon.stories.tsx
+++ b/components/Icon/Icon.stories.tsx
@@ -25,6 +25,10 @@ Default.argTypes = {
   size: { control: { type: "range", min: 30, max: 100, step: 10 } },
 };
 
+Default.parameters = {
+  layout: "centered",
+};
+
 export const Examples = () => (
   <Layout>
     {iconList.map((icon) => (
@@ -35,6 +39,12 @@ export const Examples = () => (
     ))}
   </Layout>
 );
+
+Examples.parameters = {
+  viewport: {
+    defaultViewport: "responsive",
+  },
+};
 
 const Layout = styled.div`
   display: flex;

--- a/components/Input/controls/Clear/Clear.stories.tsx
+++ b/components/Input/controls/Clear/Clear.stories.tsx
@@ -4,8 +4,11 @@ import Clear from "./Clear";
 export default {
   title: "Components/Input/Controls",
   component: Clear,
+  parameters: {
+    layout: "centered",
+  },
 };
 
-export const ClearItem = () => <Clear />;
+export const ClearItem = ({ ...args }) => <Clear {...args} />;
 
 ClearItem.storyName = "Clear";

--- a/components/Input/controls/Manage/Manage.stories.tsx
+++ b/components/Input/controls/Manage/Manage.stories.tsx
@@ -4,8 +4,11 @@ import Manage from "./Manage";
 export default {
   title: "Components/Input/Controls",
   component: Manage,
+  parameters: {
+    layout: "centered",
+  },
 };
 
-export const ManageItem = () => <Manage />;
+export const ManageItem = ({ ...args }) => <Manage {...args} />;
 
 ManageItem.storyName = "Manage";

--- a/components/Input/controls/Search/Search.stories.tsx
+++ b/components/Input/controls/Search/Search.stories.tsx
@@ -4,8 +4,11 @@ import Search from "./Search";
 export default {
   title: "Components/Input/Controls",
   component: Search,
+  parameters: {
+    layout: "centered",
+  },
 };
 
-export const SearchItem = () => <Search />;
+export const SearchItem = ({ ...args }) => <Search {...args} />;
 
 SearchItem.storyName = "Search";

--- a/components/Logo/Logo.stories.tsx
+++ b/components/Logo/Logo.stories.tsx
@@ -10,18 +10,21 @@ import type LogoProps from "./Logo.types";
 export default {
   title: "Components/Logo",
   component: Logo,
+  parameters: {
+    layout: "centered",
+  },
 };
 
 export const Default: Story<LogoProps> = ({ ...args }) => <Logo {...args} />;
 
 Default.args = {
-  height: 160,
+  height: 40,
   wordmark: true,
   symbol: false,
 };
 
 Default.argTypes = {
-  height: { control: { type: "range", min: 20, max: 200, step: 20 } },
+  height: { control: { type: "range", min: 10, max: 70, step: 10 } },
 };
 
 export const Examples = () => (

--- a/components/Logo/Logo.tsx
+++ b/components/Logo/Logo.tsx
@@ -4,7 +4,7 @@ import { Symbol, Spacing, Wordmark } from "./";
 
 import type LogoProps from "./Logo.types";
 
-const Logo = ({ symbol, wordmark = true, height = 160 }: LogoProps) => {
+const Logo = ({ symbol, wordmark = true, height = 40 }: LogoProps) => {
   return (
     <div>
       {symbol && <Symbol height={height} />}

--- a/components/MapMark/MapMark.stories.tsx
+++ b/components/MapMark/MapMark.stories.tsx
@@ -4,6 +4,9 @@ import MapMark from "./MapMark";
 export default {
   title: "Components/MapMark",
   component: MapMark,
+  parameters: {
+    layout: "centered",
+  },
 };
 
-export const Default = () => <MapMark />;
+export const Default = ({ ...args }) => <MapMark {...args} />;

--- a/components/StationInfo/LineColor/LineColor.stories.tsx
+++ b/components/StationInfo/LineColor/LineColor.stories.tsx
@@ -31,6 +31,12 @@ export const LineColorTemplate = () => (
 
 LineColorTemplate.storyName = "LineColor";
 
+LineColorTemplate.parameters = {
+  viewport: {
+    defaultViewport: "responsive",
+  },
+};
+
 const Layout = styled.div`
   display: flex;
   flex-wrap: wrap;

--- a/components/StationInfo/LineSymbol/LineSymbol.stories.tsx
+++ b/components/StationInfo/LineSymbol/LineSymbol.stories.tsx
@@ -9,6 +9,9 @@ import type LineType from "./LineSymbol.types";
 export default {
   title: "Components/StationInfo/LineSymbol",
   component: LineSymbol,
+  parameters: {
+    layout: "centered",
+  },
 };
 
 export const Default: Story<LineType> = ({ ...args }) => (

--- a/components/StationInfo/StationInfo.stories.tsx
+++ b/components/StationInfo/StationInfo.stories.tsx
@@ -20,6 +20,10 @@ Default.args = {
   name: "강남역",
 };
 
+Default.parameters = {
+  layout: "centered",
+};
+
 export const Examples = () => (
   <Layout>
     {Object.keys(stations).map((name) => (
@@ -27,6 +31,12 @@ export const Examples = () => (
     ))}
   </Layout>
 );
+
+Examples.parameters = {
+  viewport: {
+    defaultViewport: "responsive",
+  },
+};
 
 const Layout = styled.div`
   display: flex;

--- a/components/Typography/Typography.stories.tsx
+++ b/components/Typography/Typography.stories.tsx
@@ -25,6 +25,10 @@ Default.args = {
   color: "black",
 };
 
+Default.parameters = {
+  layout: "centered",
+};
+
 export const Examples = () =>
   fontSizeList.map((size) =>
     fontWeightList.map((weight) => (
@@ -50,6 +54,12 @@ export const Examples = () =>
       </Layout>
     ))
   );
+
+Examples.parameters = {
+  viewport: {
+    defaultViewport: "responsive",
+  },
+};
 
 const Layout = styled.div`
   display: flex;

--- a/foundations/Color/Palette/Palette.stories.tsx
+++ b/foundations/Color/Palette/Palette.stories.tsx
@@ -7,6 +7,11 @@ import { Typography } from "@/components";
 export default {
   title: "Foundations/Color",
   component: Palette,
+  parameters: {
+    viewport: {
+      defaultViewport: "responsive",
+    },
+  },
 };
 
 interface PaletteProps {

--- a/foundations/Color/Theme/Theme.stories.tsx
+++ b/foundations/Color/Theme/Theme.stories.tsx
@@ -7,6 +7,11 @@ import { Typography } from "@/components";
 export default {
   title: "Foundations/Color",
   component: Theme,
+  parameters: {
+    viewport: {
+      defaultViewport: "responsive",
+    },
+  },
 };
 
 interface PaletteProps {

--- a/foundations/FontSize/FontSize.stories.tsx
+++ b/foundations/FontSize/FontSize.stories.tsx
@@ -6,6 +6,11 @@ import FontSize, { fontSizeList } from "./FontSize";
 export default {
   title: "Foundations/Font Size",
   component: FontSize,
+  parameters: {
+    viewport: {
+      defaultViewport: "responsive",
+    },
+  },
 };
 
 interface FontWeightProps {

--- a/foundations/FontWeight/FontWeight.stories.tsx
+++ b/foundations/FontWeight/FontWeight.stories.tsx
@@ -7,6 +7,11 @@ import { FontSize } from "@/foundations";
 export default {
   title: "Foundations/Font Weight",
   component: FontWeight,
+  parameters: {
+    viewport: {
+      defaultViewport: "responsive",
+    },
+  },
 };
 
 interface FontWeightProps {

--- a/foundations/Transition/Transition.stories.tsx
+++ b/foundations/Transition/Transition.stories.tsx
@@ -8,6 +8,12 @@ import { FontWeight, Theme } from "@/foundations";
 export default {
   title: "Foundations/Transition",
   component: Transition,
+  parameters: {
+    layout: "centered",
+    viewport: {
+      defaultViewport: "responsive",
+    },
+  },
 };
 
 interface BoxProps {


### PR DESCRIPTION
## 📌 이슈
- close #61


<br/>

## 📝 설명

### 스토리북 viewport를 설정했어요.
- 기본 viewport는 `iPhone 12 mini` 사이즈로 설정했어요.
- viewport가 필요없거나, 넓은 화면이어야 하는 경우에는 responsive로 설정했어요.
- 하나의 요소만 있는 경우 viewport의 가운데에 위치하도록 조정했어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/156890839-d543a866-e0b9-4d62-b978-34a96e6be87e.png)
