### PR TITLE
[Feat] Button Group 컴포넌트 생성

### DIFF
--- a/components/Badge/index.ts
+++ b/components/Badge/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Badge";

--- a/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+
+import ButtonGroup from "./ButtonGroup";
+
+import type { ButtonGroupProps } from "./ButtonGroup.types";
+
+export default {
+  title: "Components/ButtonGroup",
+  component: ButtonGroup,
+} as Meta;
+
+export const Default: Story<ButtonGroupProps> = ({ ...args }) => (
+  <ButtonGroup {...args} />
+);
+
+Default.args = {
+  label: "중간 장소 추천",
+  name: "group",
+  options: [
+    {
+      id: "option1",
+      label: "필요해요",
+      value: true,
+      defaultChecked: true,
+    },
+    {
+      id: "option2",
+      label: "다음에 받을래요",
+      value: false,
+    },
+  ],
+};

--- a/components/ButtonGroup/ButtonGroup.styled.ts
+++ b/components/ButtonGroup/ButtonGroup.styled.ts
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+
+import { Theme } from "@/foundations";
+import { TypoStyle, TypoProps } from "@/components/Typography";
+
+export const Layout = styled.div`
+  display: flex;
+  position: relative;
+
+  ::before {
+    content: "";
+    position: absolute;
+    border: 1px solid ${Theme.borderColor.light};
+    border-radius: 4px;
+    box-sizing: border-box;
+    width: 100%;
+    height: 46px;
+    top: 1px;
+  }
+`;
+
+export const Label = styled.span<TypoProps>`
+  display: inline-block;
+  margin-bottom: 9px;
+  ${TypoStyle}
+`;

--- a/components/ButtonGroup/ButtonGroup.tsx
+++ b/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { Radio } from "./Radio";
+import { Layout, Label } from "./ButtonGroup.styled";
+
+import type { ButtonGroupProps } from "./ButtonGroup.types";
+
+const ButtonGroup = ({ name, label, options }: ButtonGroupProps) => {
+  return (
+    <>
+      {label && (
+        <Label color="darker" weight="bold">
+          {label}
+        </Label>
+      )}
+      <Layout>
+        {options.map(({ id, label, value, defaultChecked }) => (
+          <Radio
+            id={id}
+            name={name}
+            label={label}
+            value={value}
+            defaultChecked={defaultChecked}
+            key={id}
+          />
+        ))}
+      </Layout>
+    </>
+  );
+};
+
+export default ButtonGroup;

--- a/components/ButtonGroup/ButtonGroup.types.ts
+++ b/components/ButtonGroup/ButtonGroup.types.ts
@@ -1,0 +1,9 @@
+import type { RadioProps } from "./Radio/Radio.types";
+
+interface ButtonGroupOptions {
+  label?: string;
+  name: string;
+  options: RadioProps[];
+}
+
+export interface ButtonGroupProps extends ButtonGroupOptions {}

--- a/components/ButtonGroup/Radio/Radio.styled.ts
+++ b/components/ButtonGroup/Radio/Radio.styled.ts
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import { Theme, FontWeight, Transition } from "@/foundations";
+
+interface LabelProps {
+  for: string;
+}
+
+export const Label = styled.label<LabelProps>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+  position: relative;
+
+  height: 48px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+
+  color: ${Theme.textColor.lighter};
+  transition: ${Transition} color;
+  cursor: pointer;
+
+  :hover {
+    color: ${Theme.textColor.dark};
+  }
+`;
+
+export const Input = styled.input`
+  display: none;
+
+  :checked + ${Label} {
+    border: 1px solid ${Theme.borderColor.primary};
+    background-color: ${Theme.bgColor.white};
+    color: ${Theme.textColor.primary};
+    font-weight: ${FontWeight.bold};
+  }
+`;

--- a/components/ButtonGroup/Radio/Radio.tsx
+++ b/components/ButtonGroup/Radio/Radio.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { Label, Input } from "./Radio.styled";
+import { Typography } from "@/components";
+
+import type { RadioProps } from "./Radio.types";
+
+const Radio = ({
+  name,
+  id,
+  label,
+  value,
+  defaultChecked = false,
+}: RadioProps) => (
+  <>
+    <Input
+      type="radio"
+      name={name}
+      id={id}
+      value={value}
+      defaultChecked={defaultChecked}
+    />
+    <Label for={id}>
+      <Typography>{label}</Typography>
+    </Label>
+  </>
+);
+
+export default Radio;

--- a/components/ButtonGroup/Radio/Radio.types.ts
+++ b/components/ButtonGroup/Radio/Radio.types.ts
@@ -1,0 +1,9 @@
+interface RadioOptions {
+  name?: string;
+  id: string;
+  label: string;
+  value: any;
+  defaultChecked?: boolean;
+}
+
+export interface RadioProps extends RadioOptions {}

--- a/components/ButtonGroup/Radio/index.ts
+++ b/components/ButtonGroup/Radio/index.ts
@@ -1,0 +1,1 @@
+export { default as Radio } from "./Radio";

--- a/components/ButtonGroup/index.ts
+++ b/components/ButtonGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ButtonGroup";

--- a/components/GpsButton/index.ts
+++ b/components/GpsButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GpsButton";

--- a/components/HelperText/index.ts
+++ b/components/HelperText/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HelperText";

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -19,6 +19,7 @@ const Input = ({
   disabled,
   errorMsg,
   description,
+  placeholder = "Placeholder",
   control = "clear",
 }: InputProps) => {
   const ControlRender = (control: ControlType) => {
@@ -46,7 +47,7 @@ const Input = ({
       )}
       <Layout hasError={hasError} disabled={disabled}>
         <TextField
-          placeholder="Placeholder"
+          placeholder={placeholder}
           type={type}
           disabled={disabled}
           required={required}

--- a/components/Input/Input.types.ts
+++ b/components/Input/Input.types.ts
@@ -1,5 +1,6 @@
 import type { FormProps } from "@/types/FormProps";
 
+// prettier-ignore
 type InputType =
   | "text"
   | "search"
@@ -7,6 +8,7 @@ type InputType =
   | "password"
   | "number";
 
+// prettier-ignore
 export type ControlType =
   | "clear"
   | "manage"
@@ -18,7 +20,7 @@ interface InputOptions {
   errorMsg?: string;
   description?: string;
   control?: ControlType;
+  placeholder?: string;
 }
 
-// prettier-ignore
 export interface InputProps extends FormProps, InputOptions {}

--- a/components/Logo/index.ts
+++ b/components/Logo/index.ts
@@ -1,3 +1,4 @@
+export { default } from "./Logo";
 export { default as Spacing } from "./Spacing";
 export { default as Symbol } from "./Symbol";
 export { default as Wordmark } from "./Wordmark";

--- a/components/MapMark/index.ts
+++ b/components/MapMark/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MapMark";

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,5 @@
 export { default as Badge } from "./Badge";
+export { default as ButtonGroup } from "./ButtonGroup";
 export { default as GpsButton } from "./GpsButton";
 export { default as HelperText } from "./HelperText";
 export { default as Icon } from "./Icon";

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,9 @@
+export { default as Badge } from "./Badge";
+export { default as GpsButton } from "./GpsButton";
+export { default as HelperText } from "./HelperText";
 export { default as Icon } from "./Icon";
 export { default as Input } from "./Input";
+export { default as Logo } from "./Logo";
+export { default as MapMark } from "./MapMark";
 export { default as StationInfo } from "./StationInfo";
 export { default as Typography } from "./Typography";


### PR DESCRIPTION
## 📌 이슈
- close #50


<br/>

## 📝 설명

### Button Group 컴포넌트를 만들었어요.
- Radio 컴포넌트를 내부에 따로 만들었지만, Radio 버튼 혼자서는 큰 의미가 없어서 스토리를 작성하지는 않았어요. (필요하면 작성할게요!)
- 라디오 버튼 뒤 옵션을 처리하기 위해 `::before`와 `position: absolute`를 사용했어요.
- text hover 이펙트는 임의로 추가해서, 디자이너분들의 피드백이 필요할 것 같아요!

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/156928435-b1a9779f-f970-4329-a4e6-ce2af35cbc9a.gif)

