### PR TITLE
[Feat] Header 컴포넌트 생성

### DIFF
--- a/components/Header/Header.stories.tsx
+++ b/components/Header/Header.stories.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import Header from "./Header";
+
+export default {
+  title: "Components/Header",
+  component: Header,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export const Default = ({ ...args }) => <Header {...args} />;

--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+import { Theme } from "@/foundations";
+
+export const Layout = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  height: 64px;
+  padding: 0 20px;
+  border-bottom: 1px solid ${Theme.borderColor.lightest};
+
+  div {
+    display: flex;
+    align-items: baseline;
+    padding-left: 6px;
+  }
+
+  svg {
+    cursor: pointer;
+  }
+`;

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import { Logo, Icon } from "@/components";
+
+import { Layout } from "./Header.styled";
+
+const Header = () => {
+  return (
+    <Layout>
+      <Logo height={21} />
+      <Icon name="menu" color="black" />
+    </Layout>
+  );
+};
+
+export default Header;

--- a/components/Header/index.ts
+++ b/components/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Header";

--- a/components/Tabs/index.ts
+++ b/components/Tabs/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Tabs";

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,6 +1,7 @@
 export { default as Badge } from "./Badge";
 export { default as ButtonGroup } from "./ButtonGroup";
 export { default as GpsButton } from "./GpsButton";
+export { default as Header } from "./Header";
 export { default as HelperText } from "./HelperText";
 export { default as Icon } from "./Icon";
 export { default as Input } from "./Input";

--- a/components/index.ts
+++ b/components/index.ts
@@ -7,4 +7,5 @@ export { default as Input } from "./Input";
 export { default as Logo } from "./Logo";
 export { default as MapMark } from "./MapMark";
 export { default as StationInfo } from "./StationInfo";
+export { default as Tabs } from "./Tabs";
 export { default as Typography } from "./Typography";

--- a/foundations/Color/Theme/Theme.ts
+++ b/foundations/Color/Theme/Theme.ts
@@ -16,6 +16,7 @@ const Theme: ThemeType = {
   },
 
   borderColor: {
+    lightest: Palette.gray100,
     lighter: Palette.gray200,
     light: Palette.gray300,
     primary: Palette.blue100,

--- a/foundations/Color/Theme/Theme.types.ts
+++ b/foundations/Color/Theme/Theme.types.ts
@@ -13,6 +13,7 @@ export type selectColor =
 
 // prettier-ignore
 export type borderColor =
+  | "lightest"
   | "lighter"
   | "light"
   | "primary"


### PR DESCRIPTION
## 📌 이슈
- close #70


<br/>

## 📝 설명

### Header 컴포넌트를 만들었어요.
- `styled.header`로 시멘틱 태그를 사용했어요.
- 로고와 아이콘을 설계한대로 재사용했어요!

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/157431935-1301ef1e-a138-4a76-a544-621c118d6cd0.png)
