### PR TITLE
feat: 스토리북 패널 위치 오른쪽으로 설정

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -3,4 +3,5 @@ import theme from "./theme";
 
 addons.setConfig({
   theme,
+  panelPosition: "right",
 });


### PR DESCRIPTION
## 📌 이슈
- close #77


<br/>

## 📝 설명

- 스토리북 애드온 패널 위치를 오른쪽으로 고정했어요.
- 다만 사용자가 버튼을 눌러 위치를 바꿀 수는 있어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/157434750-ef7e4e16-b6db-47e3-adcd-f930bf4f7c63.png)

