### PR TITLE
[Feat] Navbar 컴포넌트 생성

### DIFF
--- a/components/Badge/Badge.stories.tsx
+++ b/components/Badge/Badge.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Story } from "@storybook/react";
+import { Story, Meta } from "@storybook/react";
 
 import Badge from "./Badge";
 import type { BadgeProps } from "./Badge.types";
@@ -10,9 +10,9 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const Default: Story<BadgeProps> = ({ ...args }) => <Badge {...args} />;
+export const Default: Story<BadgeProps> = (args) => <Badge {...args} />;
 
 Default.args = {
   isOngoing: true,

--- a/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -10,7 +10,7 @@ export default {
   component: ButtonGroup,
 } as Meta;
 
-export const Default: Story<ButtonGroupProps> = ({ ...args }) => (
+export const Default: Story<ButtonGroupProps> = (args) => (
   <ButtonGroup {...args} />
 );
 

--- a/components/GpsButton/GpsButton.stories.tsx
+++ b/components/GpsButton/GpsButton.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Story, Meta } from "@storybook/react";
 
 import GpsButton from "./GpsButton";
 
@@ -8,6 +9,6 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const Default = ({ ...args }) => <GpsButton {...args} />;
+export const Default: Story = () => <GpsButton />;

--- a/components/Header/Header.stories.tsx
+++ b/components/Header/Header.stories.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Story, Meta } from "@storybook/react";
 
 import Header from "./Header";
 
@@ -8,6 +9,6 @@ export default {
   parameters: {
     layout: "fullscreen",
   },
-};
+} as Meta;
 
-export const Default = ({ ...args }) => <Header {...args} />;
+export const Default: Story = () => <Header />;

--- a/components/HelperText/HelperText.stories.tsx
+++ b/components/HelperText/HelperText.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Story } from "@storybook/react";
+import { Story, Meta } from "@storybook/react";
 
 import HelperText from "./HelperText";
 
@@ -12,11 +12,9 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const Default: Story<HelperProps> = ({ ...args }) => (
-  <HelperText {...args} />
-);
+export const Default: Story<HelperProps> = (args) => <HelperText {...args} />;
 
 Default.args = {
   children: "텍스트",

--- a/components/Icon/Icon.stories.tsx
+++ b/components/Icon/Icon.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Story } from "@storybook/react";
+import { Story, Meta } from "@storybook/react";
 
 import Icon from "./Icon";
 import { iconList } from "./assets";
@@ -11,9 +11,9 @@ import type IconProps from "./Icon.types";
 export default {
   title: "Components/Icon",
   component: Icon,
-};
+} as Meta;
 
-export const Default: Story<IconProps> = ({ ...args }) => <Icon {...args} />;
+export const Default: Story<IconProps> = (args) => <Icon {...args} />;
 
 Default.args = {
   name: "edit",

--- a/components/Input/Input.stories.tsx
+++ b/components/Input/Input.stories.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 import styled from "styled-components";
+import { Story, Meta } from "@storybook/react";
 
 import Input from "./Input";
 import { Typography } from "@/components";
 
+import type { InputProps } from "./Input.types";
+
 export default {
   title: "Components/Input",
   component: Input,
-};
+} as Meta;
 
-export const Default = ({ ...args }) => <Input {...args} />;
+export const Default: Story<InputProps> = (args) => <Input {...args} />;
 
 Default.args = {
   disabled: false,

--- a/components/Input/controls/Clear/Clear.stories.tsx
+++ b/components/Input/controls/Clear/Clear.stories.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Story, Meta } from "@storybook/react";
+
 import Clear from "./Clear";
 
 export default {
@@ -7,8 +9,8 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const ClearItem = ({ ...args }) => <Clear {...args} />;
+export const ClearItem: Story = () => <Clear />;
 
 ClearItem.storyName = "Clear";

--- a/components/Input/controls/Manage/Manage.stories.tsx
+++ b/components/Input/controls/Manage/Manage.stories.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Story, Meta } from "@storybook/react";
+
 import Manage from "./Manage";
 
 export default {
@@ -7,8 +9,8 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const ManageItem = ({ ...args }) => <Manage {...args} />;
+export const ManageItem: Story = (args) => <Manage {...args} />;
 
 ManageItem.storyName = "Manage";

--- a/components/Input/controls/Search/Search.stories.tsx
+++ b/components/Input/controls/Search/Search.stories.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Story, Meta } from "@storybook/react";
+
 import Search from "./Search";
 
 export default {
@@ -7,8 +9,8 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const SearchItem = ({ ...args }) => <Search {...args} />;
+export const SearchItem: Story = (args) => <Search {...args} />;
 
 SearchItem.storyName = "Search";

--- a/components/Logo/Logo.stories.tsx
+++ b/components/Logo/Logo.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Story } from "@storybook/react";
+import { Story, Meta } from "@storybook/react";
 
 import Logo from "./Logo";
 import { Typography } from "@/components";
@@ -13,9 +13,9 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const Default: Story<LogoProps> = ({ ...args }) => <Logo {...args} />;
+export const Default: Story<LogoProps> = (args) => <Logo {...args} />;
 
 Default.args = {
   height: 40,

--- a/components/MapMark/MapMark.stories.tsx
+++ b/components/MapMark/MapMark.stories.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Story, Meta } from "@storybook/react";
+
 import MapMark from "./MapMark";
 
 export default {
@@ -7,6 +9,6 @@ export default {
   parameters: {
     layout: "centered",
   },
-};
+} as Meta;
 
-export const Default = ({ ...args }) => <MapMark {...args} />;
+export const Default: Story = () => <MapMark />;

--- a/components/Navbar/NavBody/NavBody.styled.ts
+++ b/components/Navbar/NavBody/NavBody.styled.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+import { Theme } from "@/foundations";
+
+export const Layout = styled.ul`
+  margin: 0;
+  padding: 20px 0;
+  border-bottom: 1px solid ${Theme.borderColor.lightest};
+`;

--- a/components/Navbar/NavBody/NavBody.tsx
+++ b/components/Navbar/NavBody/NavBody.tsx
@@ -3,10 +3,14 @@ import React from "react";
 import { Layout } from "./NavBody.styled";
 import { NavItem } from "@/components/Navbar";
 
-const NavBody = () => {
+import type { NavBodyProps } from "../Navbar.types";
+
+const NavBody = ({ isLogin, topItemsLogin, topItemsLogout }: NavBodyProps) => {
   return (
     <Layout>
-      <NavItem>모임 관리</NavItem>
+      {isLogin
+        ? topItemsLogin.map(({ name }) => <NavItem>{name}</NavItem>)
+        : topItemsLogout.map(({ name }) => <NavItem>{name}</NavItem>)}
     </Layout>
   );
 };

--- a/components/Navbar/NavBody/NavBody.tsx
+++ b/components/Navbar/NavBody/NavBody.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import { Layout } from "./NavBody.styled";
+import { NavItem } from "@/components/Navbar";
+
+const NavBody = () => {
+  return (
+    <Layout>
+      <NavItem>모임 관리</NavItem>
+    </Layout>
+  );
+};
+
+export default NavBody;

--- a/components/Navbar/NavBody/index.ts
+++ b/components/Navbar/NavBody/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NavBody";

--- a/components/Navbar/NavFooter/NavFooter.styled.ts
+++ b/components/Navbar/NavFooter/NavFooter.styled.ts
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+import { TypoStyle } from "@/components/Typography";
+
+export const Layout = styled.div`
+  padding: 30px 0;
+`;
+
+export const Title = styled.h2`
+  margin: 0 0 10px 0;
+  ${TypoStyle}
+`;
+
+export const ItemBox = styled.ul`
+  margin: 0 0 63px 0;
+  padding: 0;
+`;
+
+export const Logout = styled.a`
+  ${TypoStyle}
+`;

--- a/components/Navbar/NavFooter/NavFooter.tsx
+++ b/components/Navbar/NavFooter/NavFooter.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { Layout, Title, ItemBox, Logout } from "./NavFooter.styled";
 import { NavItem } from "@/components/Navbar";
-import { Typography } from "@/components";
 
 import type { NavFooterProps } from "@/components/Navbar/Navbar.types";
 

--- a/components/Navbar/NavFooter/NavFooter.tsx
+++ b/components/Navbar/NavFooter/NavFooter.tsx
@@ -4,20 +4,24 @@ import { Layout, Title, ItemBox, Logout } from "./NavFooter.styled";
 import { NavItem } from "@/components/Navbar";
 import { Typography } from "@/components";
 
-const NavFooter = () => {
+import type { NavFooterProps } from "@/components/Navbar/Navbar.types";
+
+const NavFooter = ({ isLogin, bottomItems }: NavFooterProps) => {
   return (
     <Layout>
       <Title size="cap1" color="lighter">
         고객센터
       </Title>
       <ItemBox>
-        <NavItem>이용방법</NavItem>
-        <NavItem>피드백</NavItem>
-        <NavItem>이용약관</NavItem>
+        {bottomItems.map(({ name }) => (
+          <NavItem>{name}</NavItem>
+        ))}
       </ItemBox>
-      <Logout size="body2" weight="bold" color="lighter" href="">
-        로그아웃
-      </Logout>
+      {isLogin && (
+        <Logout size="body2" weight="bold" color="lighter" href="">
+          로그아웃
+        </Logout>
+      )}
     </Layout>
   );
 };

--- a/components/Navbar/NavFooter/NavFooter.tsx
+++ b/components/Navbar/NavFooter/NavFooter.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { Layout, Title, ItemBox, Logout } from "./NavFooter.styled";
+import { NavItem } from "@/components/Navbar";
+import { Typography } from "@/components";
+
+const NavFooter = () => {
+  return (
+    <Layout>
+      <Title size="cap1" color="lighter">
+        고객센터
+      </Title>
+      <ItemBox>
+        <NavItem>이용방법</NavItem>
+        <NavItem>피드백</NavItem>
+        <NavItem>이용약관</NavItem>
+      </ItemBox>
+      <Logout size="body2" weight="bold" color="lighter" href="">
+        로그아웃
+      </Logout>
+    </Layout>
+  );
+};
+
+export default NavFooter;

--- a/components/Navbar/NavFooter/index.ts
+++ b/components/Navbar/NavFooter/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NavFooter";

--- a/components/Navbar/NavHeader/NavHeader.styled.ts
+++ b/components/Navbar/NavHeader/NavHeader.styled.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { TypoStyle } from "@/components/Typography";
 import { Theme, FontWeight } from "@/foundations";
 
-export const Header = styled.header`
+export const Header = styled.div`
   border-bottom: 1px solid ${Theme.borderColor.lightest};
 `;
 

--- a/components/Navbar/NavHeader/NavHeader.styled.ts
+++ b/components/Navbar/NavHeader/NavHeader.styled.ts
@@ -12,7 +12,7 @@ export const Hgroup = styled.hgroup`
   flex-direction: column;
   justify-content: flex-end;
 
-  // TODO: 크로스 브라우징 이슈 체크
+  /* TODO: 크로스 브라우징 이슈 체크 */
   gap: 20px;
   height: 112px;
 `;

--- a/components/Navbar/NavHeader/NavHeader.styled.ts
+++ b/components/Navbar/NavHeader/NavHeader.styled.ts
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+
+import { TypoStyle } from "@/components/Typography";
+import { Theme, FontWeight } from "@/foundations";
+
+export const Header = styled.header`
+  border-bottom: 1px solid ${Theme.borderColor.lightest};
+`;
+
+export const Hgroup = styled.hgroup`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+
+  // TODO: 크로스 브라우징 이슈 체크
+  gap: 20px;
+  height: 112px;
+`;
+
+export const Greeting = styled.h1`
+  margin: 0 0 3px 0;
+  ${TypoStyle}
+`;
+
+export const Username = styled.span`
+  ${TypoStyle}
+`;
+
+export const Email = styled.h2`
+  margin: 0;
+  ${TypoStyle}
+`;
+
+export const Message = styled.h2`
+  margin: 0;
+  ${TypoStyle}
+
+  > strong {
+    font-weight: ${FontWeight.bold};
+  }
+`;
+
+export const Button = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  width: 240px;
+  height: 52px;
+  padding: 0 20px;
+  margin: 40px 0;
+  border-radius: 6px;
+  border: none;
+
+  background-color: ${Theme.bgColor.primary};
+  cursor: pointer;
+`;

--- a/components/Navbar/NavHeader/NavHeader.tsx
+++ b/components/Navbar/NavHeader/NavHeader.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import {
+  Header,
+  Hgroup,
+  Greeting,
+  Username,
+  Email,
+  Message,
+  Button,
+} from "./NavHeader.styled";
+import { Icon, Typography, Logo } from "@/components";
+
+import type { NavHeaderProps } from "@/components/Navbar/Navbar.types";
+
+const NavHeader = ({ isLogin, user }: NavHeaderProps) => {
+  return (
+    <Header>
+      {isLogin && user ? (
+        <Hgroup>
+          <Greeting>
+            <Username size="h1" weight="bold" color="primary">
+              {user.name + " "}
+            </Username>
+            <Typography size="h1" weight="bold" color="black">
+              님 <br />
+              반가워요!
+            </Typography>
+          </Greeting>
+          <Email size="sub2" weight="regular" color="darkest">
+            {user.email}
+          </Email>
+        </Hgroup>
+      ) : (
+        <Hgroup>
+          <Logo symbol wordmark={false} height={40} />
+          <Message size="body1" color="dark" weight="regular">
+            <strong>로그인</strong>하시면 모이다를 <br />
+            편리하게 이용하실 수 있어요!
+          </Message>
+        </Hgroup>
+      )}
+
+      {/* TODO: Button 컴포넌트 교체 */}
+      <Button>
+        <Typography size="sub3" weight="bold" color="white">
+          새로운 모임 만들기
+        </Typography>
+        <Icon name="chevron-right" size={18} color="white" />
+      </Button>
+    </Header>
+  );
+};
+
+export default NavHeader;

--- a/components/Navbar/NavHeader/index.ts
+++ b/components/Navbar/NavHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NavHeader";

--- a/components/Navbar/NavItem/NavItem.stories.tsx
+++ b/components/Navbar/NavItem/NavItem.stories.tsx
@@ -1,13 +1,16 @@
 import React from "react";
+import { Story, Meta } from "@storybook/react";
 
 import NavItem from "./NavItem";
+
+import type { NavItemProps } from "./NavItem.types";
 
 export default {
   title: "Components/Navbar/NavItem",
   component: NavItem,
-};
+} as Meta;
 
-export const Default = ({ ...args }) => <NavItem {...args} />;
+export const Default: Story<NavItemProps> = (args) => <NavItem {...args} />;
 
 Default.args = {
   children: "로그인",

--- a/components/Navbar/NavItem/NavItem.stories.tsx
+++ b/components/Navbar/NavItem/NavItem.stories.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+import NavItem from "./NavItem";
+
+export default {
+  title: "Components/Navbar/NavItem",
+  component: NavItem,
+};
+
+export const Default = ({ ...args }) => <NavItem {...args} />;
+
+Default.args = {
+  children: "로그인",
+};

--- a/components/Navbar/NavItem/NavItem.styled.ts
+++ b/components/Navbar/NavItem/NavItem.styled.ts
@@ -5,6 +5,12 @@ export const Layout = styled.li`
   justify-content: space-between;
   align-items: center;
 
-  height: 40px;
+  height: 50px;
   list-style: none;
+  cursor: pointer;
+
+  svg {
+    position: relative;
+    right: -5px;
+  }
 `;

--- a/components/Navbar/NavItem/NavItem.styled.ts
+++ b/components/Navbar/NavItem/NavItem.styled.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const Layout = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  height: 40px;
+  list-style: none;
+`;

--- a/components/Navbar/NavItem/NavItem.tsx
+++ b/components/Navbar/NavItem/NavItem.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import { Layout } from "./NavItem.styled";
+import { Typography, Icon } from "@/components";
+
+import type { NavItemProps } from "./NavItem.types";
+
+const NavItem = ({ children }: NavItemProps) => {
+  return (
+    <Layout>
+      <Typography size="body1" weight="bold" color="darkest">
+        {children}
+      </Typography>
+      <Icon name="chevron-right" size={18} color="darkest" />
+    </Layout>
+  );
+};
+
+export default NavItem;

--- a/components/Navbar/NavItem/NavItem.tsx
+++ b/components/Navbar/NavItem/NavItem.tsx
@@ -8,7 +8,7 @@ import type { NavItemProps } from "./NavItem.types";
 const NavItem = ({ children }: NavItemProps) => {
   return (
     <Layout>
-      <Typography size="body1" weight="bold" color="darkest">
+      <Typography size="sub3" weight="bold" color="darkest">
         {children}
       </Typography>
       <Icon name="chevron-right" size={18} color="darkest" />

--- a/components/Navbar/NavItem/NavItem.types.ts
+++ b/components/Navbar/NavItem/NavItem.types.ts
@@ -1,0 +1,3 @@
+import { ChildrenProps } from "@/types/ComponentProps";
+
+export interface NavItemProps extends ChildrenProps {}

--- a/components/Navbar/NavItem/index.ts
+++ b/components/Navbar/NavItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NavItem";

--- a/components/Navbar/Navbar.stories.tsx
+++ b/components/Navbar/Navbar.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
 } as Meta;
 
-export const Default: Story<NavProps> = ({ ...args }) => <Navbar {...args} />;
+export const Default: Story<NavProps> = (args) => <Navbar {...args} />;
 
 Default.args = {
   isLogin: false,

--- a/components/Navbar/Navbar.stories.tsx
+++ b/components/Navbar/Navbar.stories.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+
+import Navbar from "./Navbar";
+
+import type { NavProps } from "./Navbar.types";
+
+export default {
+  title: "Components/Navbar",
+  component: Navbar,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export const Default: Story<NavProps> = ({ ...args }) => <Navbar {...args} />;
+
+Default.args = {
+  isLogin: false,
+  user: {
+    id: "haram",
+    email: "moida@gmail.com",
+    name: "하람",
+  },
+  topItemsLogin: [
+    {
+      name: "모임관리",
+      url: "/manage",
+    },
+  ],
+  topItemsLogout: [
+    {
+      name: "로그인",
+      url: "/login",
+    },
+    {
+      name: "회원가입",
+      url: "/signup",
+    },
+  ],
+  bottomItems: [
+    {
+      name: "이용방법",
+      url: "/how",
+    },
+    {
+      name: "피드백",
+      url: "/feedback",
+    },
+    {
+      name: "이용약관",
+      url: "/terms",
+    },
+  ],
+};

--- a/components/Navbar/Navbar.stories.tsx
+++ b/components/Navbar/Navbar.stories.tsx
@@ -11,7 +11,7 @@ export default {
   parameters: {
     layout: "fullscreen",
   },
-};
+} as Meta;
 
 export const Default: Story<NavProps> = ({ ...args }) => <Navbar {...args} />;
 

--- a/components/Navbar/Navbar.styled.ts
+++ b/components/Navbar/Navbar.styled.ts
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+
+import { Theme } from "@/foundations";
+
+export const Overlay = styled.div`
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.2);
+`;
+
+export const Layout = styled.nav`
+  position: fixed;
+  right: 0;
+
+  width: 300px;
+  height: 100vh;
+  padding: 20px 30px;
+  background-color: ${Theme.bgColor.white};
+`;
+
+export const CloseBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+  right: -11px;
+
+  margin-bottom: 66px;
+
+  svg {
+    cursor: pointer;
+  }
+`;

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -21,7 +21,11 @@ const Navbar = ({
           <Icon name="x" />
         </CloseBox>
         <NavHeader isLogin={isLogin} user={user} />
-        <NavBody />
+        <NavBody
+          isLogin={isLogin}
+          topItemsLogin={topItemsLogin}
+          topItemsLogout={topItemsLogout}
+        />
         <NavFooter />
       </Layout>
     </>

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { Overlay, Layout, CloseBox } from "./Navbar.styled";
+import { NavHeader, NavBody, NavFooter } from "./";
+import { Icon } from "@/components";
+
+import type { NavProps } from "./Navbar.types";
+
+const Navbar = ({
+  isLogin,
+  user,
+  topItemsLogin,
+  topItemsLogout,
+  bottomItems,
+}: NavProps) => {
+  return (
+    <>
+      <Overlay />
+      <Layout>
+        <CloseBox>
+          <Icon name="x" />
+        </CloseBox>
+        <NavHeader isLogin={isLogin} user={user} />
+        <NavBody />
+        <NavFooter />
+      </Layout>
+    </>
+  );
+};
+
+export default Navbar;

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -26,7 +26,7 @@ const Navbar = ({
           topItemsLogin={topItemsLogin}
           topItemsLogout={topItemsLogout}
         />
-        <NavFooter />
+        <NavFooter isLogin={isLogin} bottomItems={bottomItems} />
       </Layout>
     </>
   );

--- a/components/Navbar/Navbar.types.ts
+++ b/components/Navbar/Navbar.types.ts
@@ -12,10 +12,14 @@ export interface NavHeaderProps {
   user?: UserProps;
 }
 
-interface NavOptions {
+export interface NavBodyProps {
+  isLogin: LoginType;
   topItemsLogin: itemOptions[];
   topItemsLogout: itemOptions[];
+}
+
+interface NavOptions {
   bottomItems: itemOptions[];
 }
 
-export interface NavProps extends NavHeaderProps, NavOptions {}
+export interface NavProps extends NavHeaderProps, NavBodyProps, NavOptions {}

--- a/components/Navbar/Navbar.types.ts
+++ b/components/Navbar/Navbar.types.ts
@@ -18,8 +18,12 @@ export interface NavBodyProps {
   topItemsLogout: itemOptions[];
 }
 
-interface NavOptions {
+export interface NavFooterProps {
+  isLogin: LoginType;
   bottomItems: itemOptions[];
 }
 
-export interface NavProps extends NavHeaderProps, NavBodyProps, NavOptions {}
+export interface NavProps
+  extends NavHeaderProps,
+    NavBodyProps,
+    NavFooterProps {}

--- a/components/Navbar/Navbar.types.ts
+++ b/components/Navbar/Navbar.types.ts
@@ -1,0 +1,21 @@
+import { UserProps } from "@/types/UserProps";
+
+interface itemOptions {
+  name: string;
+  url: string;
+}
+
+type LoginType = boolean;
+
+export interface NavHeaderProps {
+  isLogin: LoginType;
+  user?: UserProps;
+}
+
+interface NavOptions {
+  topItemsLogin: itemOptions[];
+  topItemsLogout: itemOptions[];
+  bottomItems: itemOptions[];
+}
+
+export interface NavProps extends NavHeaderProps, NavOptions {}

--- a/components/Navbar/index.ts
+++ b/components/Navbar/index.ts
@@ -1,0 +1,4 @@
+export { default as NavItem } from "./NavItem";
+export { default as NavHeader } from "./NavHeader";
+export { default as NavBody } from "./NavBody";
+export { default as NavFooter } from "./NavFooter";

--- a/components/Navbar/index.ts
+++ b/components/Navbar/index.ts
@@ -2,3 +2,4 @@ export { default as NavItem } from "./NavItem";
 export { default as NavHeader } from "./NavHeader";
 export { default as NavBody } from "./NavBody";
 export { default as NavFooter } from "./NavFooter";
+export { default } from "./Navbar";

--- a/components/StationInfo/LineSymbol/LineSymbol.stories.tsx
+++ b/components/StationInfo/LineSymbol/LineSymbol.stories.tsx
@@ -14,9 +14,7 @@ export default {
   },
 };
 
-export const Default: Story<LineType> = ({ ...args }) => (
-  <LineSymbol {...args} />
-);
+export const Default: Story<LineType> = (args) => <LineSymbol {...args} />;
 
 Default.args = {
   name: "01호선",

--- a/components/StationInfo/StationInfo.stories.tsx
+++ b/components/StationInfo/StationInfo.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Story } from "@storybook/react";
+import { Story, Meta } from "@storybook/react";
 
 import StationInfo from "./StationInfo";
 import stations from "./assets/stations";
@@ -10,11 +10,9 @@ import type StationType from "./StationInfo.types";
 export default {
   title: "Components/StationInfo",
   component: StationInfo,
-};
+} as Meta;
 
-export const Default: Story<StationType> = ({ ...args }) => (
-  <StationInfo {...args} />
-);
+export const Default: Story<StationType> = (args) => <StationInfo {...args} />;
 
 Default.args = {
   name: "강남역",

--- a/components/Tabs/Tab/Tab.stories.tsx
+++ b/components/Tabs/Tab/Tab.stories.tsx
@@ -10,7 +10,7 @@ export default {
   component: Tab,
 } as Meta;
 
-export const Default: Story<TabProps> = ({ ...args }) => <Tab {...args} />;
+export const Default: Story<TabProps> = (args) => <Tab {...args} />;
 
 Default.args = {
   active: true,

--- a/components/Tabs/Tabs.stories.tsx
+++ b/components/Tabs/Tabs.stories.tsx
@@ -10,7 +10,7 @@ export default {
   component: Tabs,
 } as Meta;
 
-export const Default: Story<TabsProps> = ({ ...args }) => <Tabs {...args} />;
+export const Default: Story<TabsProps> = (args) => <Tabs {...args} />;
 
 Default.args = {
   tabItems: ["주 단위로 보기", "일 단위로 보기"],

--- a/components/Typography/Typography.stories.tsx
+++ b/components/Typography/Typography.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { Story } from "@storybook/react";
+import { Story, Meta } from "@storybook/react";
 
 import Typography from "./Typography";
 import { FontSize } from "@/foundations";
@@ -12,11 +12,9 @@ import type TypoProps from "./Typography.types";
 export default {
   title: "Components/Typography",
   component: Typography,
-};
+} as Meta;
 
-export const Default: Story<TypoProps> = ({ ...args }) => (
-  <Typography {...args} />
-);
+export const Default: Story<TypoProps> = (args) => <Typography {...args} />;
 
 Default.args = {
   children: "약속은 간편하게 모임은 한방에",

--- a/components/index.ts
+++ b/components/index.ts
@@ -7,6 +7,7 @@ export { default as Icon } from "./Icon";
 export { default as Input } from "./Input";
 export { default as Logo } from "./Logo";
 export { default as MapMark } from "./MapMark";
+export { default as Navbar } from "./Navbar";
 export { default as StationInfo } from "./StationInfo";
 export { default as Tabs } from "./Tabs";
 export { default as Typography } from "./Typography";

--- a/foundations/Color/Palette/Palette.stories.tsx
+++ b/foundations/Color/Palette/Palette.stories.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import styled from "styled-components";
+import { Meta } from "@storybook/react";
 
 import Palette, { paletteList } from "./Palette";
 import { Typography } from "@/components";
 
 export default {
   title: "Foundations/Color",
-  component: Palette,
   parameters: {
     viewport: {
       defaultViewport: "responsive",
     },
   },
-};
+} as Meta;
 
 interface PaletteProps {
   color: string;

--- a/foundations/Color/Theme/Theme.stories.tsx
+++ b/foundations/Color/Theme/Theme.stories.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import styled from "styled-components";
+import { Meta } from "@storybook/react";
 
 import Theme from "./Theme";
 import { Typography } from "@/components";
 
 export default {
   title: "Foundations/Color",
-  component: Theme,
   parameters: {
     viewport: {
       defaultViewport: "responsive",
     },
   },
-};
+} as Meta;
 
 interface PaletteProps {
   color: string;

--- a/foundations/FontSize/FontSize.stories.tsx
+++ b/foundations/FontSize/FontSize.stories.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 import styled from "styled-components";
+import { Meta } from "@storybook/react";
 
 import FontSize, { fontSizeList } from "./FontSize";
 
 export default {
   title: "Foundations/Font Size",
-  component: FontSize,
   parameters: {
     viewport: {
       defaultViewport: "responsive",
     },
   },
-};
+} as Meta;
 
 interface FontWeightProps {
   fontSize: number;

--- a/foundations/FontWeight/FontWeight.stories.tsx
+++ b/foundations/FontWeight/FontWeight.stories.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import styled from "styled-components";
+import { Meta } from "@storybook/react";
 
 import FontWeight, { fontWeightList } from "./FontWeight";
 import { FontSize } from "@/foundations";
 
 export default {
   title: "Foundations/Font Weight",
-  component: FontWeight,
   parameters: {
     viewport: {
       defaultViewport: "responsive",
     },
   },
-};
+} as Meta;
 
 interface FontWeightProps {
   fontWeight: number;

--- a/foundations/Transition/Transition.stories.tsx
+++ b/foundations/Transition/Transition.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { Meta } from "@storybook/react";
 
 import Transition from "./Transition";
 import { Typography } from "@/components";
@@ -7,14 +8,13 @@ import { FontWeight, Theme } from "@/foundations";
 
 export default {
   title: "Foundations/Transition",
-  component: Transition,
   parameters: {
     layout: "centered",
     viewport: {
       defaultViewport: "responsive",
     },
   },
-};
+} as Meta;
 
 interface BoxProps {
   isClicked: boolean;

--- a/types/UserProps.ts
+++ b/types/UserProps.ts
@@ -1,0 +1,5 @@
+export interface UserProps {
+  id: string;
+  email: string;
+  name: string;
+}


### PR DESCRIPTION
## 📌 이슈
- close #71
- close #64

<br/>

## 📝 설명

### Navbar 컴포넌트를 만들었어요.
- 유지보수 및 가독성을 위해 NavHeader, NavBody, NavFooter로 분리했어요.
- 각각의 props 타입을 따로 정의했어요. 그리고 extends를 통해 하나로 병합했어요.
- 각 컴포넌트별로 다른 prop을 전달해줬어요.

### 발생 가능한 문제
- NavHeader에서 레이아웃을 맞추는 과정에서, flex와 고정 height를 동시에 사용했어요.
- 기존에는 margin으로만 레이아웃이 잡혀있었는데, 로그인 상태와 비로그인 상태의 높이를 같게 하기 위한 선택이었어요.
- 현재 크롬에선 문제가 없는데, 사파리 등 다른 브라우저에서 다르게 보일 가능성이 있어요.
- 테스트가 필요해요!

### 스토리북 Meta 타입을 명시했어요.
- 동시에 ({...args}) 로 표현하던 매개변수도 (args)로 리팩토링했어요

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/157682526-7703b1ab-f6b2-4dc0-95db-437b9859bb9b.png)
![image](https://user-images.githubusercontent.com/87457066/157682546-d3e4ae9c-308a-4a7c-ad64-98bef806ee06.png)
