### PR TITLE
[Feat] Navbar 및 Header 클릭 이벤트 설정

### DIFF
--- a/components/Header/Header.stories.tsx
+++ b/components/Header/Header.stories.tsx
@@ -1,7 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
+import styled from "styled-components";
 import { Story, Meta } from "@storybook/react";
 
 import Header from "./Header";
+import { Navbar } from "@/components";
+
+import type { HeaderProps } from "./Header.types";
+import type { NavProps } from "@/components/Navbar/Navbar.types";
 
 export default {
   title: "Components/Header",
@@ -12,3 +17,64 @@ export default {
 } as Meta;
 
 export const Default: Story = () => <Header />;
+
+export const WithNavbar: Story<HeaderProps & NavProps> = (args) => {
+  const [isNavbarOpened, setIsNavbarOpened] = useState(false);
+
+  const onClickMenu = () => setIsNavbarOpened(true);
+  const onClickClose = () => setIsNavbarOpened(false);
+
+  return (
+    <Layout>
+      <Header onClickMenu={onClickMenu} />
+      {isNavbarOpened && <Navbar onClickClose={onClickClose} {...args} />}
+    </Layout>
+  );
+};
+
+WithNavbar.args = {
+  isLogin: false,
+  user: {
+    id: "haram",
+    email: "moida@gmail.com",
+    name: "하람",
+  },
+  topItemsLogin: [
+    {
+      name: "모임관리",
+      url: "/manage",
+    },
+  ],
+  topItemsLogout: [
+    {
+      name: "로그인",
+      url: "/login",
+    },
+    {
+      name: "회원가입",
+      url: "/signup",
+    },
+  ],
+  bottomItems: [
+    {
+      name: "이용방법",
+      url: "/how",
+    },
+    {
+      name: "피드백",
+      url: "/feedback",
+    },
+    {
+      name: "이용약관",
+      url: "/terms",
+    },
+  ],
+};
+
+const Layout = styled.div`
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+
+  overflow: hidden;
+`;

--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -16,8 +16,8 @@ export const Layout = styled.header`
     align-items: baseline;
     padding-left: 6px;
   }
+`;
 
-  svg {
-    cursor: pointer;
-  }
+export const MenuBox = styled.div`
+  cursor: pointer;
 `;

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,14 +1,17 @@
 import React from "react";
 
+import { Layout, MenuBox } from "./Header.styled";
 import { Logo, Icon } from "@/components";
 
-import { Layout } from "./Header.styled";
+import type { HeaderProps } from "./Header.types";
 
-const Header = () => {
+const Header = ({ onClickMenu }: HeaderProps) => {
   return (
     <Layout>
       <Logo height={21} />
-      <Icon name="menu" color="black" />
+      <MenuBox onClick={onClickMenu}>
+        <Icon name="menu" color="black" />
+      </MenuBox>
     </Layout>
   );
 };

--- a/components/Header/Header.types.ts
+++ b/components/Header/Header.types.ts
@@ -1,0 +1,7 @@
+import React from "react";
+
+interface HeaderOptions {
+  onClickMenu?: React.MouseEventHandler;
+}
+
+export interface HeaderProps extends HeaderOptions {}

--- a/components/Navbar/Navbar.styled.ts
+++ b/components/Navbar/Navbar.styled.ts
@@ -1,22 +1,28 @@
 import styled from "styled-components";
 
-import { Theme } from "@/foundations";
+import { Theme, Transition, Keyframe } from "@/foundations";
 
 export const Overlay = styled.div`
-  position: fixed;
+  position: absolute;
+  top: 0;
+  left: 0;
+
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.2);
 `;
 
 export const Layout = styled.nav`
-  position: fixed;
+  position: absolute;
+  top: 0;
   right: 0;
 
   width: 300px;
   height: 100vh;
   padding: 20px 30px;
   background-color: ${Theme.bgColor.white};
+
+  animation: ${Keyframe.slideInLeft} ${Transition};
 `;
 
 export const CloseBox = styled.div`

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -12,12 +12,13 @@ const Navbar = ({
   topItemsLogin,
   topItemsLogout,
   bottomItems,
+  onClickClose,
 }: NavProps) => {
   return (
     <>
       <Overlay />
       <Layout>
-        <CloseBox>
+        <CloseBox onClick={onClickClose}>
           <Icon name="x" />
         </CloseBox>
         <NavHeader isLogin={isLogin} user={user} />

--- a/components/Navbar/Navbar.types.ts
+++ b/components/Navbar/Navbar.types.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { UserProps } from "@/types/UserProps";
 
 interface itemOptions {
@@ -23,7 +25,12 @@ export interface NavFooterProps {
   bottomItems: itemOptions[];
 }
 
+interface NavOptions {
+  onClickClose?: React.MouseEventHandler;
+}
+
 export interface NavProps
   extends NavHeaderProps,
     NavBodyProps,
-    NavFooterProps {}
+    NavFooterProps,
+    NavOptions {}


### PR DESCRIPTION
## 📌 이슈
- close #84


<br/>

## 📝 설명

### 햄버거바 및 Close 버튼 관련 클릭 이벤트를 구현했어요.
- Header의 햄버거바 버튼을 누르면 Navbar가 열리고, Navbar의 close 버튼을 누르면 닫히도록 구현했어요.
- 클릭 이벤트 및 state는 컴포넌트 내부가 아니라 밖에서 정의하고 전달할 수 있도록 props를 설정해줬어요.

<br/>

## 📷 스크린샷
![Honeycam 2022-03-11 01-40-13](https://user-images.githubusercontent.com/87457066/157711472-8b391ad0-615f-4479-83a3-d1630cfb49f7.gif)

