### PR TITLE
[Feat] Modal 컴포넌트 생성

### DIFF
--- a/components/Modal/Modal.stories.tsx
+++ b/components/Modal/Modal.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Story, Meta } from "@storybook/react";
+
+import Modal from "./Modal";
+
+import type ModalProps from "./Modal.types";
+
+export default {
+  title: "Components/Modal",
+  component: Modal,
+  parameters: {
+    layout: "fullscreen",
+  },
+} as Meta;
+
+export const Default: Story<ModalProps> = (args) => <Modal {...args} />;
+
+Default.args = {
+  children: "비밀번호 재설정이 \n완료되었어요.",
+};

--- a/components/Modal/Modal.styled.ts
+++ b/components/Modal/Modal.styled.ts
@@ -1,0 +1,61 @@
+import styled from "styled-components";
+
+import { Theme, Transition, Keyframe } from "@/foundations";
+import { TypoStyle } from "@/components/Typography";
+
+export const Overlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.2);
+`;
+
+export const LayoutBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: 100vw;
+  height: 100vh;
+`;
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  width: 270px;
+  height: 160px;
+  padding: 30px;
+  border-radius: 6px;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+
+  background-color: ${Theme.bgColor.white};
+  animation: ${Keyframe.slideInUp} ${Transition};
+`;
+
+export const Content = styled.div`
+  padding-top: 10px;
+  ${TypoStyle}
+  white-space: pre-wrap;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const Button = styled.button`
+  background: none;
+  border: none;
+
+  ${TypoStyle}
+  cursor: pointer;
+`;

--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+
+import {
+  Overlay,
+  LayoutBox,
+  Layout,
+  Content,
+  Footer,
+  Button,
+} from "./Modal.styled";
+
+import type ModalProps from "./Modal.types";
+
+const Modal = ({ children }: ModalProps) => {
+  const [isModalOpen, setIsModalOpen] = useState(true);
+  const onClickClose = () => setIsModalOpen(false);
+
+  if (!isModalOpen) return <></>;
+  return (
+    <>
+      <Overlay />
+      <LayoutBox>
+        <Layout>
+          <Content size="sub3" weight="bold" color="darkest">
+            {children}
+          </Content>
+          <Footer>
+            <Button
+              size="sub2"
+              weight="bold"
+              color="primary"
+              onClick={onClickClose}
+            >
+              확인
+            </Button>
+          </Footer>
+        </Layout>
+      </LayoutBox>
+    </>
+  );
+};
+
+export default Modal;

--- a/components/Modal/Modal.types.ts
+++ b/components/Modal/Modal.types.ts
@@ -1,0 +1,3 @@
+import { ChildrenProps } from "@/types/ComponentProps";
+
+export default interface ModalProps extends ChildrenProps {}

--- a/components/Modal/index.ts
+++ b/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Modal";

--- a/components/index.ts
+++ b/components/index.ts
@@ -7,6 +7,7 @@ export { default as Icon } from "./Icon";
 export { default as Input } from "./Input";
 export { default as Logo } from "./Logo";
 export { default as MapMark } from "./MapMark";
+export { default as Modal } from "./Modal";
 export { default as Navbar } from "./Navbar";
 export { default as StationInfo } from "./StationInfo";
 export { default as Tabs } from "./Tabs";


### PR DESCRIPTION
## 📌 이슈
- close #72


<br/>

## 📝 설명

### Modal 컴포넌트를 만들었어요.
- `Modal.tsx` 파일에서 다음과 같이 처리한 이유는 다음과 같아요.
```typescript
  if (!isModalOpen) return <></>;
  return (
    <>
      <Overlay />
```

- 원래 의도는 다음과 같았지만 boolean 형식은 jsx 요소가 아니라는 오류가 발생했어요.
```typescript
  return (
    isModalOpen && (
    <>
      <Overlay />
```

- 만약 위 코드를 유지하면서 jsx 요소로 만들려면 다음과 같이 되어 fragment가 두번 나와야 했어요.
```typescript
  return (
    <>
      {isModalOpen && (
        <>
          <Overlay />
```

따라서 PR로 올린 코드가 가장 깔끔하다고 판단했어요 🥺

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/158060685-5dfae984-e67d-4007-9573-a0c952c96a94.png)
