### PR TITLE
[Feat] Avatar 컴포넌트 방장 prop 추가

### DIFF
--- a/components/Avatar/Avatar.stories.tsx
+++ b/components/Avatar/Avatar.stories.tsx
@@ -17,6 +17,7 @@ export const Default: Story<AvatarProps> = (args) => <Avatar {...args} />;
 
 Default.args = {
   emoji: "🐥",
+  isHost: false,
 };
 
 export const Examples = () =>

--- a/components/Avatar/Avatar.styled.ts
+++ b/components/Avatar/Avatar.styled.ts
@@ -23,6 +23,10 @@ export const Layout = styled.div<LayoutProps>`
 `;
 
 export const Emoji = styled.span`
+  display: inline-block;
+  position: relative;
+  top: 1px;
+
   font-family: emoji;
   ${TypoStyle}
 `;

--- a/components/Avatar/Avatar.styled.ts
+++ b/components/Avatar/Avatar.styled.ts
@@ -13,6 +13,7 @@ export const Layout = styled.div<LayoutProps>`
   display: inline-flex;
   justify-content: center;
   align-items: center;
+  position: relative;
 
   width: 45px;
   height: 45px;

--- a/components/Avatar/Avatar.tsx
+++ b/components/Avatar/Avatar.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 
 import { Layout, Emoji } from "./Avatar.styled";
+import { HostBadge } from "./";
 
 import AvatarProps, { EmojiObj } from "./Avatar.types";
 
-const Avatar = ({ emoji }: AvatarProps) => {
+const Avatar = ({ emoji, isHost }: AvatarProps) => {
   return (
     <Layout color={EmojiObj[emoji]}>
       <Emoji size="sub1">{emoji}</Emoji>
+      {isHost && <HostBadge />}
     </Layout>
   );
 };

--- a/components/Avatar/Avatar.types.ts
+++ b/components/Avatar/Avatar.types.ts
@@ -52,6 +52,7 @@ export type EmojiKey =
 
 interface AvatarOptions {
   emoji: EmojiKey;
+  isHost?: boolean;
 }
 
 export default interface AvatarProps extends AvatarOptions {}

--- a/components/Avatar/HostBadge/HostBadge.styled.ts
+++ b/components/Avatar/HostBadge/HostBadge.styled.ts
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+import { Theme } from "@/foundations";
+
+export const Svg = styled.svg`
+  position: absolute;
+  right: -4px;
+  bottom: 2px;
+
+  circle {
+    fill: ${Theme.bgColor.primary};
+  }
+
+  path {
+    fill: ${Theme.bgColor.white};
+    stroke: ${Theme.bgColor.white};
+  }
+`;

--- a/components/Avatar/HostBadge/HostBadge.tsx
+++ b/components/Avatar/HostBadge/HostBadge.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { Svg } from "./HostBadge.styled";
+
+const HostBadge = () => {
+  return (
+    <Svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="9" cy="9" r="9" />
+      <path
+        d="M6 7V11H12V7L10.4 8.77778L9.2 7L7.6 8.77778L6 7Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+};
+
+export default HostBadge;

--- a/components/Avatar/HostBadge/index.ts
+++ b/components/Avatar/HostBadge/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HostBadge";

--- a/components/Avatar/index.ts
+++ b/components/Avatar/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Avatar";
+export { default as HostBadge } from "./HostBadge";

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,3 +1,4 @@
+export { default as Avatar } from "./Avatar";
 export { default as Badge } from "./Badge";
 export { default as ButtonGroup } from "./ButtonGroup";
 export { default as GpsButton } from "./GpsButton";


### PR DESCRIPTION
## 📌 이슈
- close #95


<br/>

## 📝 설명

### isHost prop과 HostBadge 컴포넌트를 추가했어요.
- 위치는 figma에서 정확하게 측정했어요.
- isHost를 추가해 방장 여부에 따라 뱃지가 나오도록 만들었어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/158373248-80b2552d-22b1-4a02-a92c-03a1bcd8a5fa.png)
