### PR TITLE
[Feat] MapMark children 추가

### DIFF
--- a/components/MapMark/MapMark.stories.tsx
+++ b/components/MapMark/MapMark.stories.tsx
@@ -11,4 +11,8 @@ export default {
   },
 } as Meta;
 
-export const Default: Story = () => <MapMark />;
+export const Default: Story = (args) => <MapMark {...args} />;
+
+Default.args = {
+  children: "중간장소",
+};

--- a/components/MapMark/MapMark.styled.ts
+++ b/components/MapMark/MapMark.styled.ts
@@ -1,9 +1,45 @@
 import styled from "styled-components";
-import { Theme } from "@/foundations";
+
+import { TypoStyle } from "@/components/Typography";
+import { Theme, Palette } from "@/foundations";
 
 export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+
+  height: 80px;
+`;
+
+export const Text = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: relative;
-  transform: translate(13px, 13px);
+
+  height: 35px;
+  padding: 0 16px;
+  border-radius: 8px;
+
+  /* TODO : Theme.bgColor에 추가 */
+  background-color: ${Palette.blue300};
+  ${TypoStyle}
+
+  ::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    z-index: -1;
+
+    height: 65px;
+    width: 0px;
+    border-left: 2px solid ${Palette.blue300};
+  }
+`;
+
+export const Mark = styled.div`
+  position: relative;
 
   width: 19px;
   height: 19px;

--- a/components/MapMark/MapMark.tsx
+++ b/components/MapMark/MapMark.tsx
@@ -1,6 +1,17 @@
 import React from "react";
-import { Layout } from "./MapMark.styled";
 
-const MapMark = () => <Layout />;
+import { Layout, Text, Mark } from "./MapMark.styled";
+import type { MapMarkProps } from "./MapMark.types";
+
+const MapMark = ({ children }: MapMarkProps) => (
+  <Layout>
+    {children && (
+      <Text size="body1" weight="bold" color="white">
+        {children}
+      </Text>
+    )}
+    <Mark />
+  </Layout>
+);
 
 export default MapMark;

--- a/components/MapMark/MapMark.types.ts
+++ b/components/MapMark/MapMark.types.ts
@@ -1,0 +1,3 @@
+import { ChildrenProps } from "@/types/ComponentProps";
+
+export interface MapMarkProps extends ChildrenProps {}


### PR DESCRIPTION
## 📌 이슈
- close #97


<br/>

## 📝 설명

### MapMark Children을 추가했어요
- Button branch와 충돌을 고려해 우선 색상은 Palette를 사용했어요. 이후에 따로 속성 추가를 진행할게요.
- 가상 클래스를 사용해 선을 그었어요. border-left만 한 이유는 전체 border를 하면 내부에 미세하게 빈칸이 생기기 때문이었어요.
- children이 없을 경우엔 Mark만 나오도록 처리했어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/158592355-bab4c6ef-7619-44b2-b5aa-5aa31619f670.png)
