### PR TITLE
[Fix] MapMark 컴포넌트 중심 좌표 수정

### DIFF
--- a/components/MapMark/MapMark.styled.ts
+++ b/components/MapMark/MapMark.styled.ts
@@ -1,30 +1,29 @@
 import styled from "styled-components";
 
 import { TypoStyle } from "@/components/Typography";
-import { Theme, Palette } from "@/foundations";
+import { Theme } from "@/foundations";
 
 export const Layout = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
-
-  height: 80px;
+  position: relative;
+  width: 45px;
+  height: 45px;
 `;
 
 export const Text = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
+  position: absolute;
+  top: -48px;
+  left: -20px;
 
   height: 35px;
   padding: 0 16px;
   border-radius: 8px;
 
-  /* TODO : Theme.bgColor에 추가 */
-  background-color: ${Palette.blue300};
+  background-color: ${Theme.bgColor.point};
   ${TypoStyle}
+  white-space: nowrap;
 
   ::before {
     content: "";
@@ -34,12 +33,14 @@ export const Text = styled.div`
 
     height: 65px;
     width: 0px;
-    border-left: 2px solid ${Palette.blue300};
+    border-left: 2px solid ${Theme.bgColor.point};
   }
 `;
 
 export const Mark = styled.div`
-  position: relative;
+  position: absolute;
+  top: 13px;
+  left: 13px;
 
   width: 19px;
   height: 19px;

--- a/foundations/Color/Theme/Theme.ts
+++ b/foundations/Color/Theme/Theme.ts
@@ -7,6 +7,7 @@ const Theme: ThemeType = {
     lighter: Palette.gray100,
     light: Palette.gray200,
     primary: Palette.blue100,
+    point: Palette.blue300,
   },
 
   selectColor: {

--- a/foundations/Color/Theme/Theme.types.ts
+++ b/foundations/Color/Theme/Theme.types.ts
@@ -4,6 +4,7 @@ export type bgColor =
   | "lighter"
   | "light"
   | "primary"
+  | "point"
 
 // prettier-ignore
 export type selectColor =
@@ -89,9 +90,18 @@ interface ThemeType {
   ButtonBgColor: Record<ButtonBgColor, string>;
   ButtonTextColor: Record<ButtonTextColor, string>;
   ButtonActiveBgColor: Record<ButtonActiveBgColor, string>;
-  ButtonActiveTextColor: Record<ButtonActiveTextColor, string>;
-  ButtonDisableBgColor: Record<ButtonDisableBgColor, string>;
-  ButtonDisableBorderColor: Record<ButtonDisableBorderColor, string>;
+  ButtonActiveTextColor: Record<
+    ButtonActiveTextColor,
+    string
+  >;
+  ButtonDisableBgColor: Record<
+    ButtonDisableBgColor,
+    string
+  >;
+  ButtonDisableBorderColor: Record<
+    ButtonDisableBorderColor,
+    string
+  >;
 }
 
 export default ThemeType;

--- a/foundations/Color/Theme/Theme.types.ts
+++ b/foundations/Color/Theme/Theme.types.ts
@@ -90,18 +90,9 @@ interface ThemeType {
   ButtonBgColor: Record<ButtonBgColor, string>;
   ButtonTextColor: Record<ButtonTextColor, string>;
   ButtonActiveBgColor: Record<ButtonActiveBgColor, string>;
-  ButtonActiveTextColor: Record<
-    ButtonActiveTextColor,
-    string
-  >;
-  ButtonDisableBgColor: Record<
-    ButtonDisableBgColor,
-    string
-  >;
-  ButtonDisableBorderColor: Record<
-    ButtonDisableBorderColor,
-    string
-  >;
+  ButtonActiveTextColor: Record<ButtonActiveTextColor, string>;
+  ButtonDisableBgColor: Record<ButtonDisableBgColor, string>;
+  ButtonDisableBorderColor: Record<ButtonDisableBorderColor, string>;
 }
 
 export default ThemeType;


### PR DESCRIPTION
## 📌 이슈
- close #107
- close #103

<br/>

## 📝 설명

### MapMark 컴포넌트 중심 좌표를 수정했어요.
- absolute + relative 형식으로 관리했어요.
- MapMark가 중앙에 위치하도록 width, height 및 위치값을 조정했어요.

<br/>

## 📷 스크린샷
![image](https://user-images.githubusercontent.com/87457066/159159750-bcf9757e-fe4a-42c4-8dae-9219e050074f.png)
