### PR TITLE
[Feat] Input 컴포넌트 사용성 개선, clear 기능 추가

### DIFF
--- a/components/Input/Input.stories.tsx
+++ b/components/Input/Input.stories.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { Text } from '@/components'
 
+import { Manage, Search } from './controls'
 import Input from './Input'
 import type { InputProps } from './Input.types'
 
@@ -24,7 +25,6 @@ Default.args = {
   label: '',
   errorMsg: '',
   description: '',
-  control: 'clear',
 }
 
 export const Examples = () => (
@@ -33,8 +33,8 @@ export const Examples = () => (
       Input Controls
     </Text>
     <Input />
-    <Input control="manage" />
-    <Input control="search" />
+    <Input clearable={false} rightContent={<Manage />} />
+    <Input rightContent={<Search />} />
 
     <br />
 

--- a/components/Input/Input.types.ts
+++ b/components/Input/Input.types.ts
@@ -9,17 +9,16 @@ type InputType =
   | "password"
   | "number";
 
-// prettier-ignore
-export type ControlType =
-  | "clear"
-  | "manage"
-  | "search";
-
-export interface InputProps extends FormProps, StandardAttrProps {
+export interface InputProps
+  extends FormProps,
+    StandardAttrProps,
+    React.InputHTMLAttributes<HTMLInputElement> {
   type?: InputType
   label?: string
-  errorMsg?: string
   description?: string
-  control?: ControlType
   placeholder?: string
+  clearable?: boolean
+  hasError?: boolean
+  errorMsg?: string
+  rightContent?: React.ReactNode
 }

--- a/components/Input/controls/Clear/Clear.tsx
+++ b/components/Input/controls/Clear/Clear.tsx
@@ -1,12 +1,15 @@
+import { OnClickProps } from '@/types/ComponentProps'
+
 import { Svg } from './Clear.styled'
 
-const Clear = () => (
+const Clear = ({ onClick }: OnClickProps) => (
   <Svg
     width="30"
     height="30"
     viewBox="0 0 30 30"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    onClick={onClick}
   >
     <circle cx="15" cy="15" r="10" />
     <path

--- a/components/Input/controls/Manage/Manage.tsx
+++ b/components/Input/controls/Manage/Manage.tsx
@@ -1,9 +1,10 @@
 import { Text } from '@/components'
+import { OnClickProps } from '@/types/ComponentProps'
 
 import { Layout } from './Manage.styled'
 
-const Manage = () => (
-  <Layout>
+const Manage = ({ onClick }: OnClickProps) => (
+  <Layout onClick={onClick}>
     <Text size="body2" weight="bold" color="blue200">
       관리
     </Text>

--- a/components/Input/controls/Search/Search.tsx
+++ b/components/Input/controls/Search/Search.tsx
@@ -1,9 +1,10 @@
 import { Icon } from '@/components'
+import { OnClickProps } from '@/types/ComponentProps'
 
 import { IconBox } from './Search.styled'
 
-const Search = () => (
-  <IconBox>
+const Search = ({ onClick }: OnClickProps) => (
+  <IconBox onClick={onClick}>
     <Icon name="search" color="gray900" />
   </IconBox>
 )

--- a/types/ComponentProps.ts
+++ b/types/ComponentProps.ts
@@ -14,6 +14,10 @@ export interface LoadingProps {
   loading?: boolean
 }
 
+export interface OnClickProps {
+  onClick?: (e: React.MouseEvent) => void
+}
+
 export interface StandardAttrProps {
   className?: string
   id?: string

--- a/types/ComponentProps.ts
+++ b/types/ComponentProps.ts
@@ -15,7 +15,7 @@ export interface LoadingProps {
 }
 
 export interface OnClickProps {
-  onClick?: (e: React.MouseEvent) => void
+  onClick?: (e?: React.MouseEvent) => void
 }
 
 export interface StandardAttrProps {

--- a/utils/makeCombineRefs.ts
+++ b/utils/makeCombineRefs.ts
@@ -1,0 +1,30 @@
+/**
+ * To put multiple refs on a single element.
+ *
+ * const combineRefs = makeCombineRefs<HTMLInputElement>(ref, forwardedRef);
+ * <input ref={combineRefs} />
+ *
+ * @param {...Ref} refs One or more refs, forwarded refs, or ref callbacks
+ * @returns {function} A function that updates each ref
+ */
+export const makeCombineRefs =
+  <T extends HTMLElement>(
+    ...refs: (
+      | React.MutableRefObject<T>
+      | React.ForwardedRef<T>
+      | React.RefCallback<T>
+      | null
+      | undefined
+    )[]
+  ) =>
+  (element: T | null): void => {
+    refs.forEach((ref) => {
+      if (ref) {
+        if (typeof ref === 'function') {
+          ref(element)
+        } else if ('current' in ref) {
+          ref.current = element
+        }
+      }
+    })
+  }


### PR DESCRIPTION
## 📌 이슈

- close #165 

<br/>

## 📝 설명

- controls 사용 편의성을 위해 rightContent prop으로 변경했어요. 
- useRef가 자주 쓰일 것이므로 forwardRef를 적용해두었어요. (아마 대부분의 컴포넌트에 이 작업이 필요할 것 같아요!)
- controls에 포함되어있던 clear 아이콘을 별도로 빼서, clear 기능을 외부 로직 없이 사용할 수 있도록 변경했어요.

<br/>

## 📷 스크린샷

-

<br/>
